### PR TITLE
docs: fix typos in comments

### DIFF
--- a/crates/opencascade-sys/build.rs
+++ b/crates/opencascade-sys/build.rs
@@ -140,8 +140,8 @@ fn main() {
         fs::write(&build_marker, "").expect("Failed to update build marker");
     }
 
-    // Opencascade is now sucessfully built, export enviroment variables,
-    // so lib.rs can be used to link againts the library
+    // Opencascade is now successfully built, export environment variables,
+    // so lib.rs can be used to link against the library
     println!("cargo:rustc-env=OPENCASCADE_LIB_DIR={}", lib_dir.display());
     println!(
         "cargo:rustc-env=OPENCASCADE_INCLUDE_DIR={}",

--- a/crates/project/src/document/session.rs
+++ b/crates/project/src/document/session.rs
@@ -178,7 +178,7 @@ impl<M: Module> Session<M> {
         // This algorithm is a bit tricky, since multi user editing is allowed.
         // Here is an explanation of how it works:
         // - we can keep all transactions before the earliest transaction to undo
-        // - remember the index, where the earlies undo needs to be perfomed to each data section
+        // - remember the index, where the earliest undo needs to be performed to each data section
         //   (a separate data section is for example document data (for all users), user data of user 1, user data of user 2, ...)
         //   (if the section is not touched, set the index to the end of the list)
         // - update all transactions until the earliest to undo as follows, in reverse order:
@@ -189,7 +189,7 @@ impl<M: Module> Session<M> {
         //   - if it is undone and marked for later redo or was Failed:
         //     - try to redo it
         //     - if that fails: mark it as Failed
-        //   - if it is allready applied: keep it as is
+        //   - if it is already applied: keep it as is
 
         // This is an example of how the history might look like:
         // In this example, session 2 wants to undo 2 transactions
@@ -491,7 +491,7 @@ impl<M: Module> Session<M> {
                             }
                         }
                         TransactionState::Undone(_transaction) => {
-                            // This shuld never happen, since this method should not explicitly redo transactions
+                            // This should never happen, since this method should not explicitly redo transactions
                             panic!("Found undone transaction marked for redo");
                         }
                     };
@@ -586,7 +586,7 @@ impl<M: Module> Session<M> {
         // - Session 1: Applied - some doc  transaction <(3) undo and mark <(7) try redo
         // - Session 1: Applied - some usr1 transaction <(2) undo and mark <(8) try redo
         // - Session 2: Undone  - some usr2 transaction    <(9) redo, increase redone count
-        // - Session 2: Undone  - some usr2 transaction    <(10) do nothing, since redone count is allready 2
+        // - Session 2: Undone  - some usr2 transaction    <(10) do nothing, since redone count is already 2
         // - Session 1: Failed  - some doc  transaction <(1) mark for redo <(11) try redo
 
         // |                 after  redo               |
@@ -626,7 +626,7 @@ impl<M: Module> Session<M> {
                     });
                 }
                 TransactionState::Undone(_) => {
-                    // Undone transctions should be ignored in this step
+                    // Undone transactions should be ignored in this step
                 }
             }
         }
@@ -721,7 +721,7 @@ impl<M: Module> Session<M> {
                                 panic!("Found undone transaction marked for redo");
                             }
                             TransactionState::Failed(transaction) => {
-                                // Failed transactions are allready not applied, just mark them as undone
+                                // Failed transactions are already not applied, just mark them as undone
                                 TransactionState::Undone(transaction)
                             }
                         }
@@ -834,7 +834,7 @@ impl<M: Module> Transaction for Session<M> {
                     .map_or_else(Result::Err, |output| {
                         Ok(transaction::TransactionOutput::Shared(output))
                     }),
-                // We allready handled this case above
+                // We already handled this case above
                 Self::Args::Session(_) => unreachable!(),
             }
         }

--- a/crates/project/src/lib.rs
+++ b/crates/project/src/lib.rs
@@ -60,7 +60,7 @@ struct SharedDocumentModel<M: Module>(Rc<RefCell<InternalDocumentModel<M>>>);
 // automatically derived implementations of `Deserialize`. Alternatively, we could
 // replace each step of the deserialization process with a custom implementation with a seed
 // that contains the registry, but this would be more complex and less maintainable.
-// TODO: look into alterantives to thread local storage
+// TODO: look into alternatives to thread local storage
 thread_local! {
     static MODULE_REGISTRY: RefCell<Option<*const ModuleRegistry>> = RefCell::new(None);
 }
@@ -98,7 +98,7 @@ impl<'de> Deserialize<'de> for ErasedDocumentModel {
     where
         D: serde::Deserializer<'de>,
     {
-        // Retrive the registry from thread local storage
+        // Retrieve the registry from thread local storage
         // And use it to deserialize the model using the seed
         MODULE_REGISTRY.with(|r| {
             let registry = r.borrow();

--- a/crates/project/src/manager.rs
+++ b/crates/project/src/manager.rs
@@ -93,7 +93,7 @@ impl ProjectManager {
     /// If the user lacks permission to open the project or if the project does not exist, an error is returned.
     pub fn open(&self, location: ProjectLocation, user: User) -> Result<Project, ManagerError> {
         let mut manager = self.manager.borrow_mut();
-        // TODO: this is a temparary hack until serialization is implemented
+        // TODO: this is a temporary hack until serialization is implemented
         let project = manager
             .projects
             .entry(location)

--- a/crates/project/tests/state_management.rs
+++ b/crates/project/tests/state_management.rs
@@ -58,7 +58,7 @@ fn test_shared_state() {
         let snapshot = session2.snapshot();
         assert_eq!(
             snapshot.shared.single_word, "Test",
-            "Shared state should be applied to all allready open sessions"
+            "Shared state should be applied to all already open sessions"
         );
     }
     {

--- a/crates/project/tests/undo_redo.rs
+++ b/crates/project/tests/undo_redo.rs
@@ -52,7 +52,7 @@ fn create_undo_redo_test_setup() -> (
         assert!(session.apply(transaction.clone()).is_ok());
     }
 
-    // Now we cast away unneded information from the transactions list
+    // Now we cast away unneeded information from the transactions list
     let transactions = transactions
         .into_iter()
         .map(|(_, transaction)| match transaction {
@@ -296,7 +296,7 @@ fn test_redo_document_one_user() {
     let loc = session2.undo_redo_list().1;
     assert_eq!(loc, 0);
 
-    // We allready tested undo, so we can assume that this log is correct
+    // We already tested undo, so we can assume that this log is correct
     get_doc_log_and_clear();
     get_user_log_and_clear();
 
@@ -515,7 +515,7 @@ fn test_undo_redo_on_failed_transactions() {
         assert!(session.apply(transaction.clone()).is_ok());
     }
 
-    // Now we cast away unneded information from the transactions list
+    // Now we cast away unneeded information from the transactions list
     let transactions: Vec<TestTransaction> = transactions
         .into_iter()
         .map(|(_, transaction)| match transaction {
@@ -533,7 +533,7 @@ fn test_undo_redo_on_failed_transactions() {
     // TODO: Remove this when undo/redo doesn't copy
     session2.redo(1);
 
-    // We allready tested the undo_redo_list in the previous tests
+    // We already tested the undo_redo_list in the previous tests
 
     let session_doc_closure = project.open_document::<TestModule>(doc_uuid).unwrap();
     let session_user_closure = project.open_document::<TestModule>(doc_uuid).unwrap();


### PR DESCRIPTION
Fixes various spelling mistakes found with `typos-cli`.