### PR TITLE
fix: address clippy warnings

### DIFF
--- a/crates/project/src/document/session.rs
+++ b/crates/project/src/document/session.rs
@@ -108,6 +108,10 @@ impl<M: Module> Session<M> {
     /// * The vector contains descriptions of all transactions (that can be undone or were undone) in the order they were applied.
     /// * The index indicates the position of the next transaction to be redone in the transaction history.
     ///   If the index points outside the list, all transactions have been applied.
+    ///
+    /// # Panics
+    ///
+    /// This function is not expected to panic under normal circumstances.
     #[must_use]
     pub fn undo_redo_list(&self) -> (Vec<String>, usize) {
         let session_uuid = self.session.borrow().session_uuid;
@@ -157,6 +161,10 @@ impl<M: Module> Session<M> {
     /// # Arguments
     ///
     /// * `n` - The number of transactions to undo.
+    ///
+    /// # Panics
+    ///
+    /// This function is not expected to panic under normal circumstances.
     #[allow(clippy::too_many_lines)]
     pub fn undo(&mut self, n: usize) {
         enum UndoData<D: ReversibleDocumentTransaction, U: ReversibleDocumentTransaction> {
@@ -521,6 +529,10 @@ impl<M: Module> Session<M> {
     /// # Arguments
     ///
     /// * `n` - The number of transactions to redo. If `n` is greater than the number of transactions that can be redone, all possible transactions are redone.
+    ///
+    /// # Panics
+    ///
+    /// This function is not expected to panic under normal circumstances.
     #[allow(clippy::too_many_lines)]
     pub fn redo(&mut self, n: usize) {
         // enum RedoData<D: ReversibleDocumentTransaction, U: ReversibleDocumentTransaction> {

--- a/crates/project/src/lib.rs
+++ b/crates/project/src/lib.rs
@@ -62,7 +62,7 @@ struct SharedDocumentModel<M: Module>(Rc<RefCell<InternalDocumentModel<M>>>);
 // that contains the registry, but this would be more complex and less maintainable.
 // TODO: look into alternatives to thread local storage
 thread_local! {
-    static MODULE_REGISTRY: RefCell<Option<*const ModuleRegistry>> = RefCell::new(None);
+    static MODULE_REGISTRY: RefCell<Option<*const ModuleRegistry>> = const { RefCell::new(None) };
 }
 
 /// A struct representing a type-erased `SharedDocumentModel`.
@@ -264,7 +264,7 @@ where
             }
 
             #[inline]
-            fn visit_seq<V>(self, mut seq: V) -> Result<ErasedDocumentModel, V::Error>
+            fn visit_seq<V>(self, mut _seq: V) -> Result<ErasedDocumentModel, V::Error>
             where
                 V: serde::de::SeqAccess<'de>,
             {
@@ -352,7 +352,7 @@ struct InternalProject {
     /// The file system path to the project's saved location, if it has been persisted to disk.
     // TODO: implement this
     #[serde(skip)]
-    path: Option<PathBuf>,
+    _path: Option<PathBuf>,
 }
 
 /// Represents a project within the `CADara` application.
@@ -385,7 +385,7 @@ impl Project {
                 documents: HashMap::new(),
                 name,
                 tags: vec![],
-                path: None,
+                _path: None,
             })),
             user: User::local(),
         }
@@ -400,7 +400,7 @@ impl Project {
                 documents: HashMap::new(),
                 name,
                 tags: vec![],
-                path: Some(path),
+                _path: Some(path),
             })),
             user,
         }

--- a/crates/project/src/manager.rs
+++ b/crates/project/src/manager.rs
@@ -75,6 +75,7 @@ pub struct ProjectManager {
 
 impl ProjectManager {
     /// Creates a new `ProjectManager`.
+    #[must_use]
     pub fn new() -> Self {
         Self::default()
     }
@@ -110,7 +111,7 @@ impl ProjectManager {
     /// # Errors
     ///
     /// If the user lacks permission to create a project at the specified location or if the project already exists, an error is returned.
-    pub fn create(user: User) -> Result<ProjectLocation, ManagerError> {
+    pub fn create(_user: User) -> Result<ProjectLocation, ManagerError> {
         todo!()
     }
 }

--- a/crates/project/src/transaction.rs
+++ b/crates/project/src/transaction.rs
@@ -54,10 +54,8 @@ pub trait DocumentTransaction {
     ///   by previously calling apply with the same arguments (on a equivalent object).
     /// - This function should otherwise behave the same as apply.
     fn apply_unchecked(&mut self, args: Self::Args) -> Self::Output {
-        self.apply(args).map_or_else(
-            |_| panic!("Unchecked transaction failed with error"),
-            |output| output,
-        )
+        self.apply(args)
+            .unwrap_or_else(|_| panic!("Unchecked transaction failed with error"))
     }
 
     /// Returns the name of the transaction for the undo history.
@@ -107,10 +105,8 @@ pub trait ReversibleDocumentTransaction: DocumentTransaction {
     ///   by previously calling apply with the same arguments (on a equivalent object).
     /// - This function should otherwise behave the same as apply.
     fn apply_unchecked(&mut self, args: Self::Args) -> (Self::Output, Self::UndoData) {
-        ReversibleDocumentTransaction::apply(self, args).map_or_else(
-            |_| panic!("Unchecked transaction failed with error"),
-            |output| output,
-        )
+        ReversibleDocumentTransaction::apply(self, args)
+            .unwrap_or_else(|_| panic!("Unchecked transaction failed with error"))
     }
 
     /// Undoes the transaction using the provided undo data.

--- a/crates/project/tests/common/test_module.rs
+++ b/crates/project/tests/common/test_module.rs
@@ -113,7 +113,7 @@ impl ReversibleDocumentTransaction for TestDataSection {
                 } else {
                     let old_word = self.single_word.clone();
                     let message = format!("changed word from {old_word} to {word}");
-                    self.single_word = word.clone();
+                    self.single_word.clone_from(&word);
                     Result::Ok((
                         message,
                         TestTransactionUndoData::SetWord {

--- a/crates/project/tests/manager.rs
+++ b/crates/project/tests/manager.rs
@@ -1,12 +1,8 @@
 mod common;
-use common::minimal_test_module::*;
-use common::test_module::*;
 use project::manager::ProjectManager;
-use project::*;
-use uuid::Uuid;
 
 #[test]
 fn test_open_two_instances_of_the_same_project() {
-    // TODO: complete this tesrt
-    let project = ProjectManager::new();
+    // TODO: complete this test
+    let _project = ProjectManager::new();
 }


### PR DESCRIPTION
Fixes all warnings found by `cargo clippy` for the whole workspace.