### PR TITLE
feat(computegraph): add ComputationContext for flexible graph execution

### DIFF
--- a/crates/computegraph/src/lib.rs
+++ b/crates/computegraph/src/lib.rs
@@ -718,6 +718,7 @@ impl ComputeGraph {
         }
 
         // Run the node with the computed inputs
+        let dependency_results: Vec<&Box<dyn Any>> = dependency_results.iter().collect();
         let output_result = output_node.node.run(&dependency_results);
         // check if the result has the correct type
         if output_result
@@ -1041,7 +1042,7 @@ pub trait ExecutableNode: std::fmt::Debug + DynClone + Send + Sync {
     ///
     /// A vector of boxed dynamic values representing the output data.
     // TODO: add error handling
-    fn run(&self, input: &[Box<dyn Any>]) -> Vec<Box<dyn Any>>;
+    fn run(&self, input: &[&Box<dyn Any>]) -> Vec<Box<dyn Any>>;
 }
 
 dyn_clone::clone_trait_object!(ExecutableNode);

--- a/crates/computegraph/tests/context.rs
+++ b/crates/computegraph/tests/context.rs
@@ -1,0 +1,107 @@
+mod common;
+
+use anyhow::Result;
+use common::*;
+use computegraph::*;
+
+#[test]
+fn test_context_override() -> Result<()> {
+    let mut graph = ComputeGraph::new();
+    let addition = graph.add_node(TestNodeAddition::new(), "addition".to_string())?;
+
+    let mut ctx = ComputationContext::new();
+    ctx.set_override(addition.input_a(), 1);
+    ctx.set_override(addition.input_b(), 2);
+
+    ctx.set_override(addition.input_b(), 3);
+    ctx.set_override(addition.input_a(), 5);
+
+    assert_eq!(
+        graph.compute_with_context(addition.output(), &ctx)?,
+        8,
+        "ctx should use the latest given value"
+    );
+    assert_eq!(
+        *graph
+            .compute_untyped_with_context(addition.output().into(), &ctx)?
+            .downcast_ref::<usize>()
+            .unwrap(),
+        8,
+    );
+
+    Ok(())
+}
+
+#[test]
+fn test_context_override_skip_dependencies() -> Result<()> {
+    let mut graph = ComputeGraph::new();
+    let invalid_dep = graph.add_node(TestNodeAddition::new(), "invalid_addition".to_string())?;
+    let value = graph.add_node(TestNodeConstant::new(10), "value".to_string())?;
+    let addition = graph.add_node(TestNodeAddition::new(), "addition".to_string())?;
+
+    graph.connect(invalid_dep.output(), addition.input_a())?;
+    graph.connect(value.output(), addition.input_b())?;
+
+    assert!(matches!(
+        graph.compute(addition.output()),
+        Err(ComputeError::InputPortNotConnected(_))
+    ));
+
+    let mut ctx = ComputationContext::new();
+    ctx.set_override(addition.input_a(), 5);
+
+    assert_eq!(
+        graph
+            .compute_with_context(addition.output(), &ctx)
+            .expect("This should skip 'invalid_dep' entirely"),
+        15
+    );
+
+    Ok(())
+}
+
+#[test]
+fn test_context_fallback() -> Result<()> {
+    let mut graph = ComputeGraph::new();
+
+    let addition = graph.add_node(TestNodeAddition::new(), "addition".to_string())?;
+
+    let mut ctx = ComputationContext::new();
+    ctx.set_fallback(5_usize);
+    ctx.set_fallback(10_usize);
+
+    assert_eq!(graph.compute_with_context(addition.output(), &ctx)?, 20);
+    assert_eq!(
+        *graph
+            .compute_untyped_with_context(addition.output().into(), &ctx)?
+            .downcast_ref::<usize>()
+            .unwrap(),
+        20
+    );
+
+    Ok(())
+}
+
+#[test]
+fn test_context_priority() -> Result<()> {
+    let mut graph = ComputeGraph::new();
+
+    let zero = graph.add_node(TestNodeConstant::new(0), "zero".to_string())?;
+    let value = graph.add_node(TestNodeConstant::new(5), "value".to_string())?;
+    let addition = graph.add_node(TestNodeAddition::new(), "addition".to_string())?;
+
+    graph.connect(zero.output(), addition.input_a())?;
+    graph.connect(value.output(), addition.input_b())?;
+
+    let mut ctx = ComputationContext::new();
+    ctx.set_override(addition.input_b(), 1);
+    ctx.set_fallback(10_usize);
+
+    assert_eq!(
+        graph.compute_with_context(addition.output(), &ctx)?,
+        1,
+        "priortiy should be override > connected > fallback"
+    );
+
+    Ok(())
+}

--- a/crates/computegraph/tests/macros.rs
+++ b/crates/computegraph/tests/macros.rs
@@ -1,5 +1,5 @@
 use computegraph::{node, ExecutableNode, NodeFactory};
-use std::any::TypeId;
+use std::any::{Any, TypeId};
 
 #[test]
 fn test_macro_node() {
@@ -84,7 +84,13 @@ fn test_macro_node() {
         <Node5 as NodeFactory>::outputs(),
         vec![("output", TypeId::of::<usize>())]
     );
-    let res = ExecutableNode::run(&Node6 {}, &[Box::new("hi".to_string()), Box::new(3_usize)]);
+    let res = ExecutableNode::run(
+        &Node6 {},
+        &[
+            &(Box::new("hi".to_string()) as Box<dyn Any>),
+            &(Box::new(3_usize) as Box<dyn Any>),
+        ],
+    );
     assert_eq!(res.len(), 1);
     assert_eq!(res[0].downcast_ref::<String>().unwrap(), "hihihi");
 
@@ -99,7 +105,13 @@ fn test_macro_node() {
         <Node6 as NodeFactory>::outputs(),
         vec![("output", TypeId::of::<String>())]
     );
-    let res = ExecutableNode::run(&Node6 {}, &[Box::new("hi".to_string()), Box::new(3_usize)]);
+    let res = ExecutableNode::run(
+        &Node6 {},
+        &[
+            &(Box::new("hi".to_string()) as Box<dyn Any>),
+            &(Box::new(3_usize) as Box<dyn Any>),
+        ],
+    );
     assert_eq!(res.len(), 1);
     assert_eq!(res[0].downcast_ref::<String>().unwrap(), "hihihi");
 }

--- a/crates/computegraph_macros/src/lib.rs
+++ b/crates/computegraph_macros/src/lib.rs
@@ -440,7 +440,7 @@ fn node_impl(args: TokenStream, input: TokenStream) -> TokenStream {
         }
 
         impl ::computegraph::ExecutableNode for #node_name {
-            fn run(&self, input: &[::std::boxed::Box<dyn ::std::any::Any>]) -> Vec<::std::boxed::Box<dyn ::std::any::Any>> {
+            fn run(&self, input: &[&::std::boxed::Box<dyn ::std::any::Any>]) -> Vec<::std::boxed::Box<dyn ::std::any::Any>> {
                 let res = self.run(
                     #( input[#run_call_parameters].downcast_ref().unwrap() ),*
                 );


### PR DESCRIPTION
This PR introduces a `ComputationContext` for more flexible computations.

Input parameters to the `ComputeGraph` can now be passed using a `ComputationContext` through the `compute_untyped_with_context` and `compute_with_context` methods.
This allows us to specify external values for:
- all unconnected ports of the same type through fallbacks
- overrides to selected `InputPort`s
without modifying the existing graph.

This required the `ExecutableNode` trait to accept `&[&Box<dyn Any>]` instead of `&[Box<dyn Any>]` for input.
