### PR TITLE
fix(ci): do not check for advisories on PRs and ignore advisory found in a build dependency

### DIFF
--- a/.github/workflows/cargo-deny.yml
+++ b/.github/workflows/cargo-deny.yml
@@ -21,3 +21,5 @@ jobs:
 
       - name: Cargo deny
         uses: EmbarkStudios/cargo-deny-action@v1
+        with:
+          command: check bans licenses sources

--- a/deny.toml
+++ b/deny.toml
@@ -10,6 +10,7 @@ ignore = [
   #{ id = "RUSTSEC-0000-0000", reason = "you can specify a reason the advisory is ignored" },
   #"a-crate-that-is-yanked@0.1.1", # you can also ignore yanked crate versions if you wish
   #{ crate = "a-crate-that-is-yanked@0.1.1", reason = "you can specify why you are ignoring the yanked crate" },
+  { id = "RUSTSEC-2021-0145", reason = "this only impacts logging in 'autocxx-build', a build dependency and therefore has no risk" },
 ]
 
 [licenses]


### PR DESCRIPTION
This PR removes automatic checking of advisories on PRs. Dependabot will instead be used for that.
Additionally explicitly ignore a advisory in a logging library of a build dependency ('autocxx-build').