### PR TITLE
fix(ci): allow the AGPL-3.0 license for this repository

### DIFF
--- a/crates/computegraph/Cargo.toml
+++ b/crates/computegraph/Cargo.toml
@@ -3,6 +3,7 @@ name = "computegraph"
 version = "0.1.0"
 edition = "2021"
 license = "AGPL-3.0-only"
+publish = false
 
 [dependencies]
 thiserror = "1.0.60"

--- a/crates/computegraph_macros/Cargo.toml
+++ b/crates/computegraph_macros/Cargo.toml
@@ -3,6 +3,7 @@ name = "computegraph_macros"
 version = "0.1.0"
 edition = "2021"
 license = "AGPL-3.0-only"
+publish = false
 
 [lib]
 name = "computegraph_macros"

--- a/crates/module/Cargo.toml
+++ b/crates/module/Cargo.toml
@@ -3,6 +3,7 @@ name = "module"
 version = "0.1.0"
 edition = "2021"
 license = "AGPL-3.0-only"
+publish = false
 
 [dependencies]
 serde = { version = "1.0.195", features = ["derive", "alloc", "rc"] }

--- a/crates/occara/Cargo.toml
+++ b/crates/occara/Cargo.toml
@@ -4,6 +4,7 @@ description = "High-level Rust bindings to the OpenCASCADE B-Rep library"
 version = "0.1.0"
 edition = "2021"
 license = "AGPL-3.0-only"
+publish = false
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/crates/opencascade-sys/Cargo.toml
+++ b/crates/opencascade-sys/Cargo.toml
@@ -3,6 +3,7 @@ name = "opencascade-sys"
 version = "0.1.0"
 edition = "2021"
 license = "AGPL-3.0-only"
+publish = false
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/crates/project/Cargo.toml
+++ b/crates/project/Cargo.toml
@@ -3,6 +3,7 @@ name = "project"
 version = "0.1.0"
 edition = "2021"
 license = "AGPL-3.0-only"
+publish = false
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/crates/utils/Cargo.toml
+++ b/crates/utils/Cargo.toml
@@ -3,6 +3,7 @@ name = "utils"
 version = "0.1.0"
 edition = "2021"
 license = "AGPL-3.0-only"
+publish = false
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/deny.toml
+++ b/deny.toml
@@ -36,6 +36,7 @@ exceptions = [
   # Each entry is the crate and version constraint, and its specific allow
   # list
   #{ allow = ["Zlib"], crate = "adler32" },
+  { allow = ["AGPL-3.0"], crate = "cadara" },
 ]
 
 [bans]

--- a/deny.toml
+++ b/deny.toml
@@ -38,6 +38,7 @@ exceptions = [
   #{ allow = ["Zlib"], crate = "adler32" },
   { allow = ["AGPL-3.0"], crate = "cadara" },
 ]
+private = { ignore = true }
 
 [bans]
 # Lint level for when multiple versions of the same crate are detected


### PR DESCRIPTION
This PR explicitly allows the use of the 'AGPL-3.0' licensed source code for cadara.
GPL licensed external dependencies (like OpenCASCADE) should still be decided individually.