### PR TITLE
feat: implement viewport widget and plugin system

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3751,7 +3751,9 @@ dependencies = [
  "glam 0.27.0",
  "iced",
  "image",
+ "project",
  "rand",
+ "thiserror",
  "wgpu",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -56,6 +56,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "aligned-vec"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4aa90d7ce82d4be67b64039a3d588d38dbcc6736577de4a847025ce5b0c468d1"
+
+[[package]]
 name = "allocator-api2"
 version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -123,6 +129,23 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "arbitrary"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d5a26814d8dcb93b0e5a0ff3c6d80a8843bafb21b39e8e18a6f05471870e110"
+
+[[package]]
+name = "arg_enum_proc_macro"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ae92a5119aa49cdbcf6b9f893fe4e1d98b04ccbf82ee0584ad948a44a734dea"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.68",
 ]
 
 [[package]]
@@ -279,6 +302,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "av1-grain"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6678909d8c5d46a42abcf571271e15fdbc0a225e3646cf23762cd415046c78bf"
+dependencies = [
+ "anyhow",
+ "arrayvec",
+ "log",
+ "nom",
+ "num-rational",
+ "v_frame",
+]
+
+[[package]]
+name = "avif-serialize"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "876c75a42f6364451a033496a14c44bffe41f5f4a8236f697391f11024e596d2"
+dependencies = [
+ "arrayvec",
+]
+
+[[package]]
 name = "backtrace"
 version = "0.3.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -318,6 +364,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
 
 [[package]]
+name = "bit_field"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc827186963e592360843fb5ba4b973e145841266c1357f7180c43526f2e5b61"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -328,6 +380,12 @@ name = "bitflags"
 version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
+
+[[package]]
+name = "bitstream-io"
+version = "2.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "415f8399438eb5e4b2f73ed3152a3448b98149dda642a957ee704e1daa5cf1d8"
 
 [[package]]
 name = "block"
@@ -364,6 +422,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "built"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6a6c0b39c38fd754ac338b00a88066436389c0f029da5d37d1e01091d9b7c17"
+
+[[package]]
 name = "bumpalo"
 version = "3.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -394,6 +458,18 @@ dependencies = [
  "quote",
  "syn 2.0.68",
 ]
+
+[[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
+name = "byteorder-lite"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
 
 [[package]]
 name = "bytes"
@@ -458,6 +534,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
 dependencies = [
  "nom",
+]
+
+[[package]]
+name = "cfg-expr"
+version = "0.15.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d067ad48b8650848b989a59a86c6c36a995d02d2bf778d45c3c5d57bc2718f02"
+dependencies = [
+ "smallvec",
+ "target-lexicon",
 ]
 
 [[package]]
@@ -546,6 +632,12 @@ dependencies = [
  "termcolor",
  "unicode-width",
 ]
+
+[[package]]
+name = "color_quant"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b"
 
 [[package]]
 name = "com"
@@ -684,6 +776,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613f8cc01fe9cf1a3eb3d7f488fd2fa8388403e97039e2f73692932e291a770d"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -914,6 +1025,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "exr"
+version = "1.72.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "887d93f60543e9a9362ef8a21beedd0a833c5d9610e18c67abe15a5963dcb1a4"
+dependencies = [
+ "bit_field",
+ "flume",
+ "half",
+ "lebe",
+ "miniz_oxide",
+ "rayon-core",
+ "smallvec",
+ "zune-inflate",
+]
+
+[[package]]
 name = "fast-srgb8"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -942,6 +1069,15 @@ checksum = "5f54427cfd1c7829e2a139fcefea601bf088ebca651d2bf53ebc600eac295dae"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
+]
+
+[[package]]
+name = "flume"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55ac459de2512911e4b674ce33cf20befaba382d05b62b008afc1c8b57cbf181"
+dependencies = [
+ "spin",
 ]
 
 [[package]]
@@ -1115,6 +1251,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "gif"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fb2d69b19215e18bb912fa30f7ce15846e301408695e44e0ef719f1da9e19f2"
+dependencies = [
+ "color_quant",
+ "weezl",
+]
+
+[[package]]
 name = "gimli"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1136,6 +1282,15 @@ name = "glam"
 version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "151665d9be52f9bb40fc7966565d39666f2d1e69233571b71b87791c7e0528b3"
+
+[[package]]
+name = "glam"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e05e7e6723e3455f4818c7b26e855439f7546cf617ef669d1adedb8669e5cb9"
+dependencies = [
+ "bytemuck",
+]
 
 [[package]]
 name = "glob"
@@ -1280,6 +1435,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
 name = "hermit-abi"
 version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1333,7 +1494,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d7e6bbd197f311ed3d8b71651876b0ce01318fde52cda862a9a7a4373c9b930"
 dependencies = [
  "bitflags 2.6.0",
- "glam",
+ "glam 0.25.0",
  "log",
  "num-traits",
  "palette",
@@ -1440,7 +1601,7 @@ dependencies = [
  "bitflags 2.6.0",
  "bytemuck",
  "futures",
- "glam",
+ "glam 0.25.0",
  "glyphon",
  "guillotiere",
  "iced_graphics",
@@ -1493,6 +1654,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "image"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd54d660e773627692c524beaad361aca785a4f9f5730ce91f42aabe5bce3d11"
+dependencies = [
+ "bytemuck",
+ "byteorder",
+ "color_quant",
+ "exr",
+ "gif",
+ "image-webp",
+ "num-traits",
+ "png",
+ "qoi",
+ "ravif",
+ "rayon",
+ "rgb",
+ "tiff",
+ "zune-core",
+ "zune-jpeg",
+]
+
+[[package]]
+name = "image-webp"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d730b085583c4d789dfd07fdcf185be59501666a90c97c40162b37e4fdad272d"
+dependencies = [
+ "byteorder-lite",
+ "thiserror",
+]
+
+[[package]]
+name = "imgref"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44feda355f4159a7c757171a77de25daf6411e217b4cabd03bd6650690468126"
+
+[[package]]
 name = "indexmap"
 version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1529,6 +1729,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "interpolate_name"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c34819042dc3d3971c46c2190835914dfbe0c3c13f61449b2997f4e9722dfa60"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.68",
+]
+
+[[package]]
 name = "is-terminal"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1559,6 +1770,15 @@ name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
 dependencies = [
  "either",
 ]
@@ -1610,6 +1830,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "jpeg-decoder"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5d4a7da358eff58addd2877a45865158f0d78c911d43a5784ceb7bbf52833b0"
+
+[[package]]
 name = "js-sys"
 version = "0.3.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1652,10 +1878,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
+name = "lebe"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03087c2bad5e1034e8cace5926dec053fb3790248370865f5117a7d0213354c8"
+
+[[package]]
 name = "libc"
 version = "0.2.155"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
+
+[[package]]
+name = "libfuzzer-sys"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a96cfd5557eb82f2b83fed4955246c988d331975a002961b07c81584d107e7f7"
+dependencies = [
+ "arbitrary",
+ "cc",
+ "once_cell",
+]
 
 [[package]]
 name = "libloading"
@@ -1732,6 +1975,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c"
 
 [[package]]
+name = "loop9"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fae87c125b03c1d2c0150c90365d7d6bcc53fb73a9acaef207d2d065860f062"
+dependencies = [
+ "imgref",
+]
+
+[[package]]
 name = "lru"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1747,6 +1999,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62bb907fe88d54d8d9ce32a3cceab4218ed2f6b7d35617cafe9adf84e43919cb"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "maybe-rayon"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ea1f30cedd69f0a2954655f7188c6a834246d2bcf1e315e2ac40c4b24dc9519"
+dependencies = [
+ "cfg-if",
+ "rayon",
 ]
 
 [[package]]
@@ -1904,6 +2166,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "new_debug_unreachable"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
+
+[[package]]
 name = "nom"
 version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1911,6 +2179,53 @@ checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
 dependencies = [
  "memchr",
  "minimal-lexical",
+]
+
+[[package]]
+name = "noop_proc_macro"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0676bb32a98c1a483ce53e500a81ad9c3d5b3f7c920c28c24e9cb0980d0b5bc8"
+
+[[package]]
+name = "num-bigint"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-derive"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.68",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
+dependencies = [
+ "num-bigint",
+ "num-integer",
+ "num-traits",
 ]
 
 [[package]]
@@ -2351,6 +2666,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
+
+[[package]]
 name = "presser"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2372,7 +2693,7 @@ version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d37c51ca738a55da99dc0c4a34860fd675453b8b36209178c2249bb13651284"
 dependencies = [
- "toml_edit",
+ "toml_edit 0.21.1",
 ]
 
 [[package]]
@@ -2413,6 +2734,19 @@ name = "profiling"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43d84d1d7a6ac92673717f9f6d1518374ef257669c24ebc5ac25d5033828be58"
+dependencies = [
+ "profiling-procmacros",
+]
+
+[[package]]
+name = "profiling-procmacros"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8021cf59c8ec9c432cfc2526ac6b8aa508ecaf29cd415f271b8406c1b851c3fd"
+dependencies = [
+ "quote",
+ "syn 2.0.68",
+]
 
 [[package]]
 name = "project"
@@ -2426,6 +2760,21 @@ dependencies = [
  "utils",
  "uuid",
 ]
+
+[[package]]
+name = "qoi"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f6d64c71eb498fe9eae14ce4ec935c555749aef511cca85b5568910d6e48001"
+dependencies = [
+ "bytemuck",
+]
+
+[[package]]
+name = "quick-error"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quick-xml"
@@ -2451,6 +2800,18 @@ version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
+ "libc",
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
  "rand_core",
 ]
 
@@ -2459,6 +2820,9 @@ name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom",
+]
 
 [[package]]
 name = "range-alloc"
@@ -2473,10 +2837,80 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f60fcc7d6849342eff22c4350c8b9a989ee8ceabc4b481253e8946b9fe83d684"
 
 [[package]]
+name = "rav1e"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd87ce80a7665b1cce111f8a16c1f3929f6547ce91ade6addf4ec86a8dda5ce9"
+dependencies = [
+ "arbitrary",
+ "arg_enum_proc_macro",
+ "arrayvec",
+ "av1-grain",
+ "bitstream-io",
+ "built",
+ "cfg-if",
+ "interpolate_name",
+ "itertools 0.12.1",
+ "libc",
+ "libfuzzer-sys",
+ "log",
+ "maybe-rayon",
+ "new_debug_unreachable",
+ "noop_proc_macro",
+ "num-derive",
+ "num-traits",
+ "once_cell",
+ "paste",
+ "profiling",
+ "rand",
+ "rand_chacha",
+ "simd_helpers",
+ "system-deps",
+ "thiserror",
+ "v_frame",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "ravif"
+version = "0.11.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67376f469e7e7840d0040bbf4b9b3334005bb167f814621326e4c7ab8cd6e944"
+dependencies = [
+ "avif-serialize",
+ "imgref",
+ "loop9",
+ "quick-error",
+ "rav1e",
+ "rayon",
+ "rgb",
+]
+
+[[package]]
 name = "raw-window-handle"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20675572f6f24e9e76ef639bc5552774ed45f1c30e2951e1e99c59888861c539"
+
+[[package]]
+name = "rayon"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b418a60154510ca1a002a752ca9714984e21e4241e804d32555251faf8b78ffa"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
+]
 
 [[package]]
 name = "read-fonts"
@@ -2558,6 +2992,15 @@ name = "renderdoc-sys"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19b30a45b0cd0bcca8037f3d0dc3421eaf95327a17cad11964fb8179b4fc4832"
+
+[[package]]
+name = "rgb"
+version = "0.8.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7439be6844e40133eda024efd85bf07f59d0dd2f59b10c00dd6cfb92cc5c741"
+dependencies = [
+ "bytemuck",
+]
 
 [[package]]
 name = "roxmltree"
@@ -2697,6 +3140,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "0.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79e674e01f999af37c49f70a6ede167a8a60b2503e56c5599532a65baa5969a0"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2707,6 +3159,15 @@ name = "simd-adler32"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe"
+
+[[package]]
+name = "simd_helpers"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95890f873bec569a0362c235787f3aca6e1e887302ba4840839bcc6459c42da6"
+dependencies = [
+ "quote",
+]
 
 [[package]]
 name = "siphasher"
@@ -2833,6 +3294,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+dependencies = [
+ "lock_api",
+]
+
+[[package]]
 name = "spirv"
 version = "0.3.0+sdk-1.3.268.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2930,6 +3400,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "system-deps"
+version = "6.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3e535eb8dded36d55ec13eddacd30dec501792ff23a0b1682c38601b8cf2349"
+dependencies = [
+ "cfg-expr",
+ "heck",
+ "pkg-config",
+ "toml",
+ "version-compare",
+]
+
+[[package]]
+name = "target-lexicon"
+version = "0.12.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1fc403891a21bcfb7c37834ba66a547a8f402146eba7265b5a6d88059c9ff2f"
+
+[[package]]
 name = "tempfile"
 version = "3.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2992,6 +3481,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tiff"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba1310fcea54c6a9a4fd1aad794ecc02c31682f6bfbecdf460bf19533eed1e3e"
+dependencies = [
+ "flate2",
+ "jpeg-decoder",
+ "weezl",
+]
+
+[[package]]
 name = "tiny-skia"
 version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3046,10 +3546,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
+name = "toml"
+version = "0.8.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f49eb2ab21d2f26bd6db7bf383edc527a7ebaee412d17af4d40fdccd442f335"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit 0.22.14",
+]
+
+[[package]]
 name = "toml_datetime"
 version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4badfd56924ae69bcc9039335b2e017639ce3f9b001c393c1b2d1ef846ce2cbf"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "toml_edit"
@@ -3059,7 +3574,20 @@ checksum = "6a8534fd7f78b5405e860340ad6575217ce99f38d4d5c8f2442cb5ecb50090e1"
 dependencies = [
  "indexmap 2.2.6",
  "toml_datetime",
- "winnow",
+ "winnow 0.5.40",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f21c7aaf97f1bd9ca9d4f9e73b0a6c74bd5afef56f2bc931943a6e1c37e04e38"
+dependencies = [
+ "indexmap 2.2.6",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "winnow 0.6.13",
 ]
 
 [[package]]
@@ -3192,10 +3720,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "v_frame"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6f32aaa24bacd11e488aa9ba66369c7cd514885742c9fe08cfe85884db3e92b"
+dependencies = [
+ "aligned-vec",
+ "num-traits",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "version-compare"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "852e951cb7832cb45cb1169900d19760cfa39b82bc0ea9c0e5a14ae88411c98b"
+
+[[package]]
 name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+
+[[package]]
+name = "viewport"
+version = "0.1.0"
+dependencies = [
+ "bytemuck",
+ "computegraph",
+ "glam 0.27.0",
+ "iced",
+ "image",
+ "rand",
+ "wgpu",
+]
 
 [[package]]
 name = "walkdir"
@@ -3422,6 +3980,12 @@ dependencies = [
  "js-sys",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "weezl"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53a85b86a771b1c87058196170769dd264f66c0782acf1ae6cc51bfd64b39082"
 
 [[package]]
 name = "wgpu"
@@ -3863,6 +4427,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "winnow"
+version = "0.6.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59b5e5f6c299a3c7890b876a2a587f3115162487e704907d9b6cd29473052ba1"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "x11-dl"
 version = "2.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3961,4 +4534,28 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.68",
+]
+
+[[package]]
+name = "zune-core"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f423a2c17029964870cfaabb1f13dfab7d092a62a29a89264f4d36990ca414a"
+
+[[package]]
+name = "zune-inflate"
+version = "0.2.54"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73ab332fe2f6680068f3582b16a24f90ad7096d5d39b974d1c0aff0125116f02"
+dependencies = [
+ "simd-adler32",
+]
+
+[[package]]
+name = "zune-jpeg"
+version = "0.4.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec866b44a2a1fd6133d363f073ca1b179f438f99e7e5bfb1e33f7181facfe448"
+dependencies = [
+ "zune-core",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4438,6 +4438,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "workspace"
+version = "0.1.0"
+dependencies = [
+ "computegraph",
+ "viewport",
+]
+
+[[package]]
 name = "x11-dl"
 version = "2.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ members = [
   "crates/project",
   "crates/opencascade-sys",
   "crates/occara",
+  "crates/viewport",
   "crates/computegraph",
   "crates/computegraph_macros",
   "crates/cadara",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,5 +9,6 @@ members = [
   "crates/computegraph_macros",
   "crates/cadara",
   "crates/module",
+  "crates/workspace",
 ]
 resolver = "2"

--- a/crates/viewport/Cargo.toml
+++ b/crates/viewport/Cargo.toml
@@ -15,3 +15,5 @@ image = "0.25.1"
 rand = "0.8.5"
 wgpu = "0.19.4"
 computegraph = { path = "../computegraph" }
+thiserror = "1.0.61"
+project = { path = "../project" }

--- a/crates/viewport/Cargo.toml
+++ b/crates/viewport/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "viewport"
+version = "0.1.0"
+edition = "2021"
+license = "AGPL-3.0-only"
+publish = false
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+bytemuck = "1.15.0"
+glam = { version = "0.27.0", features = ["bytemuck"] }
+iced = { version = "0.12.1", features = ["advanced"] }
+image = "0.25.1"
+rand = "0.8.5"
+wgpu = "0.19.4"
+computegraph = { path = "../computegraph" }

--- a/crates/viewport/src/lib.rs
+++ b/crates/viewport/src/lib.rs
@@ -1,0 +1,218 @@
+//! # Viewport
+//!
+//! The viewport is the central UI component for rendering and interacting with documents in `CADara`.
+//! It manages a scene graph and coordinates plugins and extensions to enable rich visualization and editing.
+//!
+//! ## Scene Graph
+//!
+//! Instead of directly rendering a scene, the user of this library can define a scene graph using a [`ComputeGraph`] struct.
+//!
+//! This allows for a declarative approach to defining scenes, handling asynchronous operations and caching seamlessly.
+//! TODO: update this when it's clear how the scene graph will work.
+//!
+//! ## Building the Scene Graph
+//!
+//! The scene graph can be modified in two ways: plugins and extensions.
+//!
+//! ### Plugins
+//!
+//! Plugins are the main way to modify the scene graph, and often correspond to a specific workspace.
+//! Multiple plugins can be added to the viewport and will be executed in order.
+//! Plugins come in two forms: add and replace.
+//! - Add plugins receive the scene graph from the previous plugin and can fully modify it.
+//! - Replace plugins first reset the scene graph before executing, effectively replacing all previous plugins.
+//!
+//! This allows Plugins to modify the scene graph incrementally or completely replace it.
+//! Imagine editing a Sketch in a CAD document: the viewport should still show the rest of the document, while
+//! displaying extra information and tools specific to the selected Sketch.
+//!
+//! ### Extensions
+//!
+//! Nodes (or subgraphs) in the scene graph can be annotated with extensions. Extensions are run by plugins (through a helper library)
+//! TODO: I have no idea yet about how extensions should function (if at all)
+//!
+//! ### Render Nodes
+//!
+//! Render nodes are responsible for rendering the scene every frame and should be as lightweight as possible.
+//! A node can be marked as a render node by setting the `render` flag to true. TODO: or is it metadata?
+//! The viewport will automatically the `context` input port with the rendering context. TODO: update when it's clear how this works.
+//!
+//! ### Edges
+//!
+//! An edge connects the output of one node to the input of another.
+//! The type of the output must match the type of the input.
+//!
+//! ### Execution
+//!
+//! TODO: move this section to the ComputeGraph documentation, here we should link to it.
+//!
+//! Depending on the type of the nodes, they are run at different times:
+//! - Operation nodes are run when their inputs change or when the external data they listen to changes.
+//! - Render nodes are run every frame.
+//!
+//! If a Operation node hase no path to a Render node, it can be optimized out.
+//! This allows for lazy computation and caching.
+//!
+//! Nodes are only run after the complete scene graph has been built.
+
+use computegraph::ComputeGraph;
+use iced::widget::shader;
+
+// TODO: or is this a plugin?
+pub trait SceneExtension {
+    type Input;
+    type Output;
+
+    fn run(&self, scene_graph: ComputeGraph, input: Self::Input) -> (ComputeGraph, Self::Output);
+}
+
+#[derive(Clone, Default)]
+pub struct Viewport {}
+
+impl<Message> shader::Program<Message> for Viewport {
+    type State = ();
+
+    type Primitive = Primitive;
+
+    fn draw(
+        &self,
+        _state: &Self::State,
+        _cursor: iced::advanced::mouse::Cursor,
+        _bounds: iced::Rectangle,
+    ) -> Self::Primitive {
+        Primitive::default()
+    }
+}
+
+#[derive(Debug, Default)]
+pub struct Primitive {}
+
+#[derive(Debug)]
+pub struct Pipeline {
+    pipeline: wgpu::RenderPipeline,
+}
+
+impl Pipeline {
+    fn new(
+        device: &wgpu::Device,
+        _queue: &wgpu::Queue,
+        format: wgpu::TextureFormat,
+        _target_size: iced::Size<u32>,
+    ) -> Self {
+        let shader = device.create_shader_module(wgpu::ShaderModuleDescriptor {
+            label: None,
+            source: wgpu::ShaderSource::Wgsl(std::borrow::Cow::Borrowed(
+                r#"
+struct VertexOutput {
+    @builtin(position) clip_position: vec4<f32>,
+    @location(0) tex_coords: vec2<f32>,
+};
+
+@vertex
+fn vs_main(@builtin(vertex_index) in_vertex_index: u32) -> VertexOutput {
+    var out: VertexOutput;
+    let x = f32(1 - i32(in_vertex_index & 1u) * 2);
+    let y = f32(1 - i32(in_vertex_index >> 1u) * 2);
+    out.clip_position = vec4<f32>(x, y, 0.0, 1.0);
+    out.tex_coords = vec2<f32>(
+        f32(in_vertex_index & 1u),
+        f32(in_vertex_index >> 1u),
+    );
+    return out;
+}
+
+@fragment
+fn fs_main(in: VertexOutput) -> @location(0) vec4<f32> {
+    return vec4<f32>(0.0, 0.0, 1.0, 1.0);
+}
+        "#,
+            )),
+        });
+
+        let pipeline_layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
+            label: None,
+            bind_group_layouts: &[],
+            push_constant_ranges: &[],
+        });
+
+        let pipeline = device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
+            label: None,
+            layout: Some(&pipeline_layout),
+            vertex: wgpu::VertexState {
+                module: &shader,
+                entry_point: "vs_main",
+                buffers: &[],
+            },
+            fragment: Some(wgpu::FragmentState {
+                module: &shader,
+                entry_point: "fs_main",
+                targets: &[Some(wgpu::ColorTargetState {
+                    format,
+                    blend: None,
+                    write_mask: wgpu::ColorWrites::ALL,
+                })],
+            }),
+            primitive: wgpu::PrimitiveState::default(),
+            depth_stencil: None,
+            multisample: wgpu::MultisampleState::default(),
+            multiview: None,
+        });
+
+        Self { pipeline }
+    }
+}
+
+impl shader::Primitive for Primitive {
+    fn prepare(
+        &self,
+        format: wgpu::TextureFormat,
+        device: &wgpu::Device,
+        queue: &wgpu::Queue,
+        _bounds: iced::Rectangle,
+        target_size: iced::Size<u32>,
+        _scale_factor: f32,
+        storage: &mut shader::Storage,
+    ) {
+        if !storage.has::<Pipeline>() {
+            storage.store(Pipeline::new(device, queue, format, target_size));
+        }
+        let _pipeline = storage.get_mut::<Pipeline>().unwrap();
+    }
+
+    fn render(
+        &self,
+        storage: &shader::Storage,
+        target: &wgpu::TextureView,
+        _target_size: iced::Size<u32>,
+        viewport: iced::Rectangle<u32>,
+        encoder: &mut wgpu::CommandEncoder,
+    ) {
+        let pipeline = storage.get::<Pipeline>().unwrap();
+
+        let mut render_pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+            label: None,
+            color_attachments: &[Some(wgpu::RenderPassColorAttachment {
+                view: target,
+                resolve_target: None,
+                ops: wgpu::Operations {
+                    load: wgpu::LoadOp::Load,
+                    store: wgpu::StoreOp::Store,
+                },
+            })],
+            depth_stencil_attachment: None,
+            timestamp_writes: None,
+            occlusion_query_set: None,
+        });
+
+        render_pass.set_pipeline(&pipeline.pipeline);
+        render_pass.set_viewport(
+            viewport.x as f32,
+            viewport.y as f32,
+            viewport.width as f32,
+            viewport.height as f32,
+            0.0,
+            1.0,
+        );
+        render_pass.draw(0..3, 0..1);
+    }
+}

--- a/crates/viewport/src/pipeline.rs
+++ b/crates/viewport/src/pipeline.rs
@@ -1,0 +1,490 @@
+use std::any::TypeId;
+
+use computegraph::{
+    ComputationContext, ComputeGraph, DynamicNode, InputPort, InputPortUntyped, NodeFactory,
+    NodeHandle, OutputPort, OutputPortUntyped,
+};
+
+use crate::InputEvents;
+
+/// Errors that can occur when creating a new [`ViewportPlugin`] or [`DynamicViewportPlugin`]
+#[derive(thiserror::Error, Debug)]
+pub enum ViewportPluginValidationError {
+    /// Plugin is missing required output port 'output'
+    #[error("Plugin is missing required output port 'output'")]
+    MissingOutputPort,
+    /// Output port 'scene' is missing or has invalid type
+    #[error("Output port 'scene' is missing or has invalid type")]
+    InvalidSceneOutputPort,
+    /// Incompatible configuration for 'input' and 'scene' input ports
+    #[error("Incompatible configuration for 'input' and 'scene' input ports")]
+    InputPortMismatch,
+}
+
+/// Errors that can occur when adding a new plugin to the [`ViewportPipeline`]
+#[derive(thiserror::Error, Debug)]
+pub enum PipelineAddError {
+    /// Mismatch between output type of last layer and input type
+    #[error(
+        "Mismatch between output type of last layer ({output_type:?}) and input type ({input_type:?})"
+    )]
+    TypeMismatch {
+        input_type: TypeId,
+        output_type: TypeId,
+    },
+    /// Cannot add subsequent plugin to empty pipeline
+    #[error("Cannot add subsequent plugin to empty pipeline")]
+    SubsequentPluginInEmptyPipeline,
+}
+
+/// Errors that can occur when executing a [`ViewportPipeline`]
+#[derive(thiserror::Error, Debug)]
+pub enum ExecuteError {
+    /// [`ViewportPipeline`] is empty
+    #[error("ViewportPipeline is empty")]
+    EmptyPipeline,
+    /// No 'result' output found
+    #[error("No 'result' output found")]
+    NoResultOutput,
+    /// Failed to execute the final [`SceneGraph`]
+    #[error("Failed to execute the final SceneGraph: {0}")]
+    ComputeError(#[from] computegraph::ComputeError),
+}
+
+#[derive(Debug, Clone)]
+struct ViewportPluginNode {
+    node: computegraph::NodeHandle,
+    output: computegraph::OutputPortUntyped,
+    scene_output: computegraph::OutputPort<SceneGraph>,
+}
+
+#[derive(Clone)]
+pub struct SceneGraphBuilder<T> {
+    pub graph: ComputeGraph,
+    pub initial_state: OutputPort<T>,
+    pub render_node: RenderNodePorts<T>,
+    pub update_node: UpdateNodePorts<T>,
+}
+
+#[derive(Clone)]
+pub struct RenderNodePorts<T> {
+    // state in
+    pub state_in: InputPort<T>,
+    // primitive out
+    pub primitive_out: OutputPort<Box<dyn iced::widget::shader::Primitive>>,
+}
+
+#[derive(Clone)]
+pub struct UpdateNodePorts<T> {
+    // events in
+    pub events_in: InputPort<InputEvents>,
+    // state in
+    pub state_in: InputPort<T>,
+    // state out
+    pub state_out: OutputPort<T>,
+}
+
+#[derive(Debug, Clone)]
+pub struct SceneGraph {
+    pub graph: ComputeGraph,
+    init_state: OutputPortUntyped,
+    render_state_in: InputPortUntyped,
+    render_primitive_out: OutputPort<Box<dyn iced::widget::shader::Primitive>>,
+}
+
+impl<T> From<SceneGraphBuilder<T>> for SceneGraph {
+    fn from(scene_graph: SceneGraphBuilder<T>) -> Self {
+        Self {
+            graph: scene_graph.graph,
+            init_state: scene_graph.initial_state.into(),
+            render_state_in: scene_graph.render_node.state_in.into(),
+            render_primitive_out: scene_graph.render_node.primitive_out,
+        }
+    }
+}
+
+/// Represents a pipeline for managing and executing viewport plugins.
+///
+/// The [`ViewportPipeline`] struct is the core component for managing and executing
+/// [`ViewportPlugin`]s, which themselves are used to describe the exact behavior of
+/// the viewport.
+///
+/// TODO: add examples
+#[derive(Debug, Default, Clone)]
+pub struct ViewportPipeline {
+    graph: ComputeGraph,
+    nodes: Vec<ViewportPluginNode>,
+}
+
+/// Represents the position of a plugin in the viewport pipeline.
+#[derive(Debug, Clone)]
+enum PluginPosition {
+    /// Indicates that the plugin is the first in the pipeline.
+    ///
+    /// An `Initial` plugin:
+    /// - Does not receive input from previous plugins.
+    /// - Is responsible for initializing the scene graph
+    Initial,
+    /// Indicates that the plugin is added after other plugins in the pipeline.
+    ///
+    /// A `Subsequent` plugin:
+    /// - Receives input from the previous plugin in the pipeline.
+    /// - May add to or transform the scene graph created by earlier plugins.
+    Subsequent,
+}
+
+/// A plugin for the [`ViewportPipeline`].
+///
+/// A [`ViewportPlugin`] is used to define the behavior of the viewport, and can be either an
+/// initial plugin (no input) or a subsequent plugin (receives input from the previous plugin).
+///
+/// To create a new [`ViewportPlugin`], use the [`ViewportPlugin::new`] method on a 'node' created
+/// by the [`computegraph::node`] macro.
+///
+/// If the specific plugin type is not known at compile time, use [`DynamicViewportPlugin`] instead.
+///
+/// # Requirements
+///
+/// For a 'node' to be a valid [`ViewportPlugin`], it must adhere to the following requirements:
+/// 1. It must have an output port named "output". The type of "output" is application-specific, but
+///    should contain any data needed for subsequent plugins to change the scene graph.
+/// 2. It must have an output port named "scene" of type [`SceneGraph`] that contains
+///    the scene graph, which is used to render the viewport.
+///
+/// If the plugin is an subsequent plugin, (i.e., the plugin should be connected to the "scene" and "output" output ports of the previous plugin),
+/// it also must additionally implement the following requirements:
+/// 3. It must have an input port named "input". The type of "input" should be exactly the same as the type of "output" of the previous plugin.
+/// 4. It must have an input port named "scene" of type [`SceneGraph`] that will contain the scene graph as generated by the previous plugin.
+///
+/// TODO: add examples
+///
+/// In this example, `InitialCounterNode` is an initial plugin (no input),
+/// while `IncrementCounterNode` is a subsequent plugin (has both "input" and "scene" inputs).
+#[derive(Debug, Clone)]
+pub struct ViewportPlugin<T: NodeFactory>(T, PluginPosition);
+
+impl<T: NodeFactory> ViewportPlugin<T> {
+    /// Creates a new [`ViewportPlugin`] from a 'node'.
+    /// Refer to the [`ViewportPlugin`] documentation for more information on the requirements for a valid plugin.
+    ///
+    /// # Errors
+    ///
+    /// This function will return an error if the node does not meet the requirements as specified in [`ViewportPlugin`].
+    ///
+    /// See [`ViewportPluginValidationError`] for specific error types.
+    pub fn new(node: T) -> Result<Self, ViewportPluginValidationError> {
+        validate_plugin(&T::inputs(), &T::outputs()).map(|t| Self(node, t))
+    }
+}
+
+/// A dynamic plugin for the [`ViewportPipeline`].
+///
+/// This is the dynamic version of a [`ViewportPlugin`].
+/// It is recommended to use [`ViewportPlugin`] if the specific plugin type is known at compile time.
+///
+/// Refer to [`ViewportPlugin`] for more information on how to create a valid plugin.
+/// TODO: add examples
+#[derive(Debug, Clone)]
+pub struct DynamicViewportPlugin(DynamicNode, PluginPosition);
+
+impl DynamicViewportPlugin {
+    /// Creates a new [`DynamicViewportPlugin`] from a [`DynamicNode`].
+    /// Refer to the [`ViewportPlugin`] and [`DynamicViewportPlugin`] documentation for more information on the requirements for a valid plugin.
+    ///
+    /// # Errors
+    ///
+    /// This function will return an error if the node does not meet the requirements as specified in [`ViewportPlugin`].
+    ///
+    /// See [`ViewportPluginValidationError`] for specific error types.
+    pub fn new(node: DynamicNode) -> Result<Self, ViewportPluginValidationError> {
+        validate_plugin(node.inputs(), node.outputs()).map(|t| Self(node, t))
+    }
+}
+
+fn validate_plugin(
+    inputs: &[(&str, TypeId)],
+    outputs: &[(&str, TypeId)],
+) -> Result<PluginPosition, ViewportPluginValidationError> {
+    let input_type = inputs
+        .iter()
+        .find_map(|n| if n.0 == "input" { Some(n.1) } else { None });
+    let output_type = outputs
+        .iter()
+        .find_map(|n| if n.0 == "output" { Some(n.1) } else { None });
+    let scene_input_type = inputs
+        .iter()
+        .find_map(|n| if n.0 == "scene" { Some(n.1) } else { None });
+    let scene_output_type = outputs
+        .iter()
+        .find_map(|n| if n.0 == "scene" { Some(n.1) } else { None });
+
+    if let Some(t) = scene_output_type {
+        if t != TypeId::of::<SceneGraph>() {
+            return Err(ViewportPluginValidationError::InvalidSceneOutputPort);
+        }
+    } else {
+        return Err(ViewportPluginValidationError::InvalidSceneOutputPort);
+    }
+
+    if output_type.is_none() {
+        return Err(ViewportPluginValidationError::MissingOutputPort);
+    }
+
+    match (input_type, scene_input_type) {
+        (Some(_), None) | (None, Some(_)) => Err(ViewportPluginValidationError::InputPortMismatch),
+        (Some(_), Some(scene)) => {
+            if scene == TypeId::of::<SceneGraph>() {
+                Ok(PluginPosition::Subsequent)
+            } else {
+                Err(ViewportPluginValidationError::InputPortMismatch)
+            }
+        }
+        (None, None) => Ok(PluginPosition::Initial),
+    }
+}
+
+impl ViewportPipeline {
+    /// Adds a plugin to the viewport pipeline.
+    ///
+    /// This method appends the given plugin to the end of the pipeline. The plugin's position
+    /// (Initial or Subsequent) determines how it's integrated:
+    ///
+    /// - `Initial`: Standalone plugin without inputs from previous plugins.
+    /// - `Subsequent`: Plugin that receives inputs from the preceding plugin in the pipeline.
+    ///
+    /// If the specific plugin type is not known at compile time, use [`ViewportPipeline::add_dynamic_plugin`] with a
+    /// [`DynamicViewportPlugin`] instead.
+    ///
+    /// # Parameters
+    /// - `plugin`: The plugin to add to the pipeline
+    ///
+    /// # Returns
+    ///
+    /// Ok(()) if the plugin was successfully added to the pipeline
+    ///
+    /// # Errors
+    ///
+    /// Returns a `Err(PipelineAddError)` if the plugin could not be added to the pipeline.
+    ///
+    /// # Panics
+    ///
+    /// This function will panic if a duplicate node name is generated internally.
+    /// This should never happen under normal circumstances as node names are generated uniquely.
+    pub fn add_plugin<T: computegraph::NodeFactory + 'static>(
+        &mut self,
+        plugin: ViewportPlugin<T>,
+    ) -> Result<(), PipelineAddError> {
+        let this = &mut *self;
+        let node = NodeHandle {
+            node_name: format!("node-{}", this.nodes.len()),
+        };
+
+        let handle: NodeHandle = match this.graph.add_node(plugin.0, node.node_name.clone()) {
+            Ok(node) => node.into(),
+            Err(err) => match err {
+                computegraph::AddError::DuplicateName(_) => {
+                    panic!("Node names are only given by our selves")
+                }
+            },
+        };
+
+        match this.connect_plugin(handle, plugin.1) {
+            Ok(v) => Ok(v),
+            Err(err) => {
+                // Clean up
+                let _ = this.graph.remove_node(node);
+                Err(err)
+            }
+        }
+    }
+
+    /// Adds a dynamic plugin to the viewport pipeline.
+    ///
+    /// If the specific plugin type is not known at compile time, use this method,
+    /// otherwise use [`ViewportPipeline::add_plugin`] instead.
+    ///
+    /// See [`ViewportPipeline::add_plugin`] for more information on how plugins are integrated.
+    ///
+    /// # Parameters
+    /// - `plugin`: The plugin to add to the pipeline
+    ///
+    /// # Returns
+    ///
+    /// Ok(()) if the plugin was successfully added to the pipeline
+    ///
+    /// # Errors
+    ///
+    /// Returns a `Err(PipelineAddError)` if the plugin could not be added to the pipeline.
+    ///
+    /// # Panics
+    ///
+    /// This function will panic if a duplicate node name is generated internally.
+    /// This should never happen under normal circumstances as node names are generated uniquely.
+    pub fn add_dynamic_plugin(
+        &mut self,
+        node: DynamicViewportPlugin,
+    ) -> Result<(), PipelineAddError> {
+        let this = &mut *self;
+        let handle = NodeHandle {
+            node_name: format!("node-{}", this.nodes.len()),
+        };
+
+        let handle: NodeHandle = match this.graph.add_node_dynamic(node.0, handle.node_name) {
+            Ok(node) => node,
+            Err(err) => match err {
+                computegraph::AddError::DuplicateName(_) => {
+                    panic!("this should not happen")
+                }
+            },
+        };
+
+        match this.connect_plugin(handle.clone(), node.1) {
+            Ok(v) => Ok(v),
+            Err(err) => {
+                // Clean up
+                let _ = this.graph.remove_node(handle);
+                Err(err)
+            }
+        }
+    }
+
+    fn connect_plugin(
+        &mut self,
+        node: NodeHandle,
+        node_type: PluginPosition,
+    ) -> Result<(), PipelineAddError> {
+        let input = node.clone().to_input_port("input");
+        let output = node.clone().to_output_port("output");
+        let scene_input = node.clone().to_input_port("scene");
+        let scene_output = node.clone().to_output_port("scene");
+
+        match (node_type, self.nodes.last()) {
+            (PluginPosition::Initial, None) => {
+                // No connecting needed, we are done!
+                Ok(())
+            }
+            (PluginPosition::Initial, Some(_)) => {
+                // This node will be added as if it is the first node
+                Ok(())
+            }
+            (PluginPosition::Subsequent, Some(prev_node)) => {
+                // We now need to connect the node with the previous node
+                self.graph
+                    .connect_untyped(prev_node.output.clone(), input)
+                    .map_err(|e| match e {
+                        computegraph::ConnectError::TypeMismatch { expected, found } => {
+                            PipelineAddError::TypeMismatch {
+                                input_type: expected,
+                                output_type: found,
+                            }
+                        }
+                        computegraph::ConnectError::InputPortAlreadyConnected { .. }
+                        | computegraph::ConnectError::NodeNotFound(_) => {
+                            panic!("We just added the node")
+                        }
+                        computegraph::ConnectError::InputPortNotFound(_)
+                        | computegraph::ConnectError::OutputPortNotFound(_) => {
+                            panic!("We checked that already")
+                        }
+                    })?;
+                match self
+                    .graph
+                    .connect_untyped(prev_node.scene_output.clone().into(), scene_input)
+                {
+                    Ok(_) => (),
+                    Err(e) => match e {
+                        computegraph::ConnectError::InputPortAlreadyConnected { .. }
+                        | computegraph::ConnectError::NodeNotFound(_) => {
+                            panic!("We just added the node")
+                        }
+                        computegraph::ConnectError::TypeMismatch { .. }
+                        | computegraph::ConnectError::InputPortNotFound(_)
+                        | computegraph::ConnectError::OutputPortNotFound(_) => {
+                            panic!("We checked that already")
+                        }
+                    },
+                }
+                Ok(())
+            }
+            (PluginPosition::Subsequent, None) => {
+                Err(PipelineAddError::SubsequentPluginInEmptyPipeline)
+            }
+        }?;
+
+        self.nodes.push(ViewportPluginNode {
+            node,
+            output,
+            scene_output: scene_output.to_typed(),
+        });
+
+        Ok(())
+    }
+
+    /// Removes the most recently added plugin from the viewport pipeline.
+    ///
+    /// This method removes the last plugin added to the pipeline, effectively
+    /// undoing the last [`ViewportPipeline::add_plugin`] or [`ViewportPipeline::add_dynamic_plugin`] operation.
+    ///
+    /// # Panics
+    ///
+    /// This function will panic if the last added node is not found in the graph.
+    /// This should never happen under normal circumstances as the node was previously added to the graph.
+    pub fn remove_last_plugin(&mut self) {
+        if let Some(node) = self.nodes.pop() {
+            match self.graph.remove_node(node.node) {
+                Ok(()) => {}
+                Err(computegraph::RemoveNodeError::NodeNotFound(_)) => {
+                    panic!("We added it, so it should exist")
+                }
+            }
+        }
+    }
+
+    /// Computes the final [`SceneGraph`] of the viewport pipeline.
+    ///
+    /// This function traverses the pipeline and computes the `SceneGraph` output
+    /// from the last plugin in the chain.
+    ///
+    /// # Returns
+    ///
+    /// The final [`SceneGraph`] for rendering inside the viewport.
+    ///
+    /// # Errors
+    ///
+    /// - `Err(ExecuteError::EmptyPipeline)` if the pipeline is empty.
+    /// - `Err(ExecuteError::ComputeError)` if there's an error during computation
+    ///     of the added [`ViewportPlugin`]s.
+    pub fn compute_scene(&self) -> Result<SceneGraph, ExecuteError> {
+        let last_node = self.nodes.last().ok_or(ExecuteError::EmptyPipeline)?;
+        let scene = self.graph.compute(last_node.scene_output.clone())?;
+
+        Ok(scene)
+    }
+
+    pub(crate) fn compute_primitive(
+        &self,
+    ) -> Result<Box<dyn iced::widget::shader::Primitive>, ExecuteError> {
+        let scene = self.compute_scene()?;
+
+        let a = scene.graph.compute_untyped(scene.init_state).unwrap();
+
+        let mut ctx = ComputationContext::default();
+        ctx.set_override_untyped(scene.render_state_in, a);
+
+        scene
+            .graph
+            .compute_with_context(scene.render_primitive_out, &ctx)
+            .map_err(ExecuteError::ComputeError)
+    }
+
+    /// Returns the number of plugins in the viewport pipeline.
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.nodes.len()
+    }
+
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+}

--- a/crates/viewport/tests/pipeline/basic_operations.rs
+++ b/crates/viewport/tests/pipeline/basic_operations.rs
@@ -1,0 +1,88 @@
+use crate::common::*;
+use viewport::{ExecuteError, ViewportPipeline, ViewportPlugin};
+
+#[test]
+fn test_viewport_plugins() {
+    let mut pipeline = ViewportPipeline::default();
+    assert_eq!(pipeline.len(), 0);
+
+    let initial_node = ViewportPlugin::new(InitialCounterNode {}).unwrap();
+    let subsequent_node = ViewportPlugin::new(IncrementCounterNode {}).unwrap();
+
+    pipeline.add_plugin(initial_node.clone()).unwrap();
+    assert_eq!(pipeline.len(), 1);
+    assert_eq!(node_count(&pipeline).unwrap(), 1);
+
+    pipeline.add_plugin(initial_node.clone()).unwrap();
+    assert_eq!(pipeline.len(), 2);
+    assert_eq!(node_count(&pipeline).unwrap(), 1);
+
+    pipeline.add_plugin(subsequent_node.clone()).unwrap();
+    assert_eq!(pipeline.len(), 3);
+    assert_eq!(node_count(&pipeline).unwrap(), 2);
+
+    pipeline.add_plugin(initial_node.clone()).unwrap();
+    assert_eq!(pipeline.len(), 4);
+    assert_eq!(node_count(&pipeline).unwrap(), 1);
+
+    pipeline.add_plugin(subsequent_node.clone()).unwrap();
+    assert_eq!(pipeline.len(), 5);
+    assert_eq!(node_count(&pipeline).unwrap(), 2);
+
+    pipeline.add_plugin(subsequent_node.clone()).unwrap();
+    assert_eq!(pipeline.len(), 6);
+    assert_eq!(node_count(&pipeline).unwrap(), 3);
+
+    // Now remove all nodes step by step
+
+    pipeline.remove_last_plugin();
+    assert_eq!(pipeline.len(), 5);
+    assert_eq!(node_count(&pipeline).unwrap(), 2);
+
+    pipeline.remove_last_plugin();
+    assert_eq!(pipeline.len(), 4);
+    assert_eq!(node_count(&pipeline).unwrap(), 1);
+
+    pipeline.remove_last_plugin();
+    assert_eq!(pipeline.len(), 3);
+    assert_eq!(node_count(&pipeline).unwrap(), 2);
+
+    pipeline.remove_last_plugin();
+    assert_eq!(pipeline.len(), 2);
+    assert_eq!(node_count(&pipeline).unwrap(), 1);
+
+    pipeline.remove_last_plugin();
+    assert_eq!(pipeline.len(), 1);
+    assert_eq!(node_count(&pipeline).unwrap(), 1);
+
+    pipeline.remove_last_plugin();
+    assert_eq!(pipeline.len(), 0);
+
+    // Try to readd a node, checks if the node was really deleted from the internal graph
+    pipeline.add_plugin(initial_node.clone()).unwrap();
+    assert_eq!(pipeline.len(), 1);
+}
+
+#[test]
+fn test_remove_node_from_empty_pipeline() {
+    let mut pipeline = ViewportPipeline::default();
+    pipeline.remove_last_plugin();
+    assert_eq!(pipeline.len(), 0);
+}
+
+#[test]
+fn test_compute_single_node_pipeline() {
+    let mut pipeline = ViewportPipeline::default();
+    pipeline
+        .add_plugin(ViewportPlugin::new(InitialCounterNode {}).unwrap())
+        .unwrap();
+    let result = node_count(&pipeline);
+    assert_eq!(result.unwrap(), 1);
+}
+
+#[test]
+fn test_compute_empty_pipeline() {
+    let pipeline = ViewportPipeline::default();
+    let result = pipeline.compute_scene();
+    assert!(matches!(result, Err(ExecuteError::EmptyPipeline)));
+}

--- a/crates/viewport/tests/pipeline/basic_operations.rs
+++ b/crates/viewport/tests/pipeline/basic_operations.rs
@@ -83,6 +83,7 @@ fn test_compute_single_node_pipeline() {
 #[test]
 fn test_compute_empty_pipeline() {
     let pipeline = ViewportPipeline::default();
-    let result = pipeline.compute_scene();
+    let project = project::Project::new("project".to_string());
+    let result = pipeline.compute_scene(project.create_session());
     assert!(matches!(result, Err(ExecuteError::EmptyPipeline)));
 }

--- a/crates/viewport/tests/pipeline/common.rs
+++ b/crates/viewport/tests/pipeline/common.rs
@@ -1,0 +1,135 @@
+use computegraph::{node, ComputeGraph};
+use iced::widget::shader::Primitive;
+use viewport::{
+    InputEvents, RenderNodePorts, SceneGraph, SceneGraphBuilder, UpdateNodePorts, ViewportPipeline,
+};
+
+#[derive(Clone)]
+pub struct State {}
+
+#[derive(Debug)]
+pub struct SomePrimitive();
+impl Primitive for SomePrimitive {
+    fn prepare(
+        &self,
+        _format: wgpu::TextureFormat,
+        _device: &wgpu::Device,
+        _queue: &wgpu::Queue,
+        _bounds: iced::Rectangle,
+        _target_size: iced::Size<u32>,
+        _scale_factor: f32,
+        _storage: &mut iced::widget::shader::Storage,
+    ) {
+    }
+
+    fn render(
+        &self,
+        _storage: &iced::widget::shader::Storage,
+        _target: &wgpu::TextureView,
+        _target_size: iced::Size<u32>,
+        _viewport: iced::Rectangle<u32>,
+        _encoder: &mut wgpu::CommandEncoder,
+    ) {
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct InitState();
+#[node(InitState)]
+fn run(&self) -> State {
+    State {}
+}
+
+#[derive(Debug, Clone)]
+pub struct RenderNode();
+#[node(RenderNode)]
+fn run(&self, _state: &State) -> Box<dyn Primitive> {
+    Box::new(SomePrimitive())
+}
+
+#[derive(Debug, Clone)]
+pub struct UpdateNode();
+#[node(UpdateNode)]
+fn run(&self, state: &State, _events: &InputEvents) -> State {
+    (*state).clone()
+}
+
+#[derive(Debug, Clone)]
+pub struct ConstantNode(usize);
+
+#[node(ConstantNode)]
+fn run(&self) -> usize {
+    self.0
+}
+
+#[derive(Debug, Clone)]
+pub struct CounterState {
+    output_node: ConstantNodeHandle,
+    value: usize,
+}
+
+#[derive(Debug, Clone)]
+pub struct InitialCounterNode;
+
+#[node(InitialCounterNode -> (scene, output))]
+fn run(&self) -> (SceneGraph, CounterState) {
+    let mut graph = ComputeGraph::default();
+    let output_node = graph
+        .add_node(ConstantNode(1), "output".to_string())
+        .unwrap();
+    let init_state_node = graph.add_node(InitState(), "init".to_string()).unwrap();
+    let render_node = graph.add_node(RenderNode(), "render".to_string()).unwrap();
+    let update_node = graph.add_node(UpdateNode(), "update".to_string()).unwrap();
+    (
+        SceneGraphBuilder {
+            graph,
+            initial_state: init_state_node.output(),
+            render_node: RenderNodePorts {
+                state_in: render_node.input_state(),
+                primitive_out: render_node.output(),
+            },
+            update_node: UpdateNodePorts {
+                state_in: update_node.input_state(),
+                events_in: update_node.input_events(),
+                state_out: update_node.output(),
+            },
+        }
+        .into(),
+        CounterState {
+            output_node,
+            value: 1,
+        },
+    )
+}
+
+#[derive(Debug, Clone)]
+pub struct IncrementCounterNode;
+
+#[node(IncrementCounterNode -> (scene, output))]
+fn run(&self, scene: &SceneGraph, input: &CounterState) -> (SceneGraph, CounterState) {
+    // TODO: it should be possible to opt out of caching to not clone everything everytime
+    // TODO: [`SceneGraph::graph`] should not be pub, node macro should therefore support generics
+    let mut scene = (*scene).clone();
+    scene.graph.remove_node(input.output_node.clone()).unwrap();
+    let value = input.value + 1;
+    let output_node = scene
+        .graph
+        .add_node(ConstantNode(value), "output".to_string())
+        .unwrap();
+    (scene, CounterState { output_node, value })
+}
+
+/// the number of ViewportPlugins that were executed in the pipelines
+///
+/// For use with [`InitialCounterNode`] and [`IncrementCounterNode`]
+pub fn node_count(pipeline: &ViewportPipeline) -> Result<usize, Box<dyn std::error::Error>> {
+    let g = pipeline.compute_scene()?.graph;
+    let out_port = computegraph::OutputPortUntyped {
+        node: computegraph::NodeHandle {
+            node_name: "output".to_string(),
+        },
+        output_name: "output",
+    }
+    .to_typed();
+    Ok(g.compute(out_port)?)
+}

--- a/crates/viewport/tests/pipeline/common.rs
+++ b/crates/viewport/tests/pipeline/common.rs
@@ -1,7 +1,8 @@
 use computegraph::{node, ComputeGraph};
 use iced::widget::shader::Primitive;
 use viewport::{
-    InputEvents, RenderNodePorts, SceneGraph, SceneGraphBuilder, UpdateNodePorts, ViewportPipeline,
+    RenderNodePorts, SceneGraph, SceneGraphBuilder, UpdateNodePorts, ViewportEvent,
+    ViewportPipeline,
 };
 
 #[derive(Clone)]
@@ -50,7 +51,7 @@ fn run(&self, _state: &State) -> Box<dyn Primitive> {
 #[derive(Debug, Clone)]
 pub struct UpdateNode();
 #[node(UpdateNode)]
-fn run(&self, state: &State, _events: &InputEvents) -> State {
+fn run(&self, state: &State, _event: &ViewportEvent) -> State {
     (*state).clone()
 }
 
@@ -90,7 +91,7 @@ fn run(&self) -> (SceneGraph, CounterState) {
             },
             update_node: UpdateNodePorts {
                 state_in: update_node.input_state(),
-                events_in: update_node.input_events(),
+                event_in: update_node.input_event(),
                 state_out: update_node.output(),
             },
         }

--- a/crates/viewport/tests/pipeline/common.rs
+++ b/crates/viewport/tests/pipeline/common.rs
@@ -124,7 +124,8 @@ fn run(&self, scene: &SceneGraph, input: &CounterState) -> (SceneGraph, CounterS
 ///
 /// For use with [`InitialCounterNode`] and [`IncrementCounterNode`]
 pub fn node_count(pipeline: &ViewportPipeline) -> Result<usize, Box<dyn std::error::Error>> {
-    let g = pipeline.compute_scene()?.graph;
+    let p = project::Project::new("project".to_string());
+    let g = pipeline.compute_scene(p.create_session())?.graph;
     let out_port = computegraph::OutputPortUntyped {
         node: computegraph::NodeHandle {
             node_name: "output".to_string(),

--- a/crates/viewport/tests/pipeline/dynamic_nodes.rs
+++ b/crates/viewport/tests/pipeline/dynamic_nodes.rs
@@ -1,0 +1,30 @@
+use crate::common::*;
+use computegraph::node;
+use viewport::{DynamicViewportPlugin, ViewportPipeline, ViewportPluginValidationError};
+
+#[test]
+fn test_add_plugin_dynamic() {
+    let mut graph = ViewportPipeline::default();
+
+    // Test adding a valid dynamic node
+    let dynamic_node = DynamicViewportPlugin::new(InitialCounterNode {}.into()).unwrap();
+    assert!(graph.add_dynamic_plugin(dynamic_node).is_ok());
+    assert_eq!(graph.len(), 1);
+
+    // Test adding another valid dynamic node
+    let dynamic_node2 = DynamicViewportPlugin::new(IncrementCounterNode {}.into()).unwrap();
+    assert!(graph.add_dynamic_plugin(dynamic_node2).is_ok());
+    assert_eq!(graph.len(), 2);
+
+    // Test adding an invalid dynamic node
+    #[derive(Clone, Debug)]
+    struct InvalidNode;
+    #[node(InvalidNode)]
+    fn run(&self) {}
+
+    let result = DynamicViewportPlugin::new(InvalidNode {}.into());
+    assert!(matches!(
+        result,
+        Err(ViewportPluginValidationError::InvalidSceneOutputPort)
+    ));
+}

--- a/crates/viewport/tests/pipeline/error_handling.rs
+++ b/crates/viewport/tests/pipeline/error_handling.rs
@@ -1,0 +1,85 @@
+use crate::common::*;
+use computegraph::node;
+use viewport::{
+    PipelineAddError, SceneGraph, ViewportPipeline, ViewportPlugin, ViewportPluginValidationError,
+};
+
+#[test]
+fn test_invalid_node_errors() {
+    // Test a node without output port
+    #[derive(Debug, Clone)]
+    struct InvalidNode1;
+    #[node(InvalidNode1)]
+    fn run(&self) {}
+
+    let result = ViewportPlugin::new(InvalidNode1 {});
+    assert!(matches!(
+        result,
+        Err(ViewportPluginValidationError::InvalidSceneOutputPort)
+    ));
+
+    // Test adding a node with invalid graph output type
+    #[derive(Debug, Clone)]
+    struct InvalidNode2;
+    #[node(InvalidNode2 -> graph)]
+    fn run(&self) -> String {
+        "Invalid graph output".to_string()
+    }
+
+    let result = ViewportPlugin::new(InvalidNode2 {});
+    assert!(matches!(
+        result,
+        Err(ViewportPluginValidationError::InvalidSceneOutputPort)
+    ));
+}
+
+#[test]
+fn test_incompatible_input_ports() {
+    #[derive(Debug, Clone)]
+    struct IncompatibleNode;
+    #[node(IncompatibleNode -> (scene, output))]
+    fn run(&self, _input: &usize) -> (SceneGraph, usize) {
+        unimplemented!()
+    }
+
+    let result = ViewportPlugin::new(IncompatibleNode {});
+    assert!(matches!(
+        result,
+        Err(ViewportPluginValidationError::InputPortMismatch)
+    ));
+}
+
+#[test]
+fn test_type_mismatch_error() {
+    let mut graph = ViewportPipeline::default();
+    graph
+        .add_plugin(ViewportPlugin::new(InitialCounterNode {}).unwrap())
+        .unwrap();
+
+    // Try to add a node with mismatched input type
+    #[derive(Debug, Clone)]
+    struct MismatchedNode;
+    #[node(MismatchedNode -> (scene, output))]
+    fn run(
+        &self,
+        _scene: &SceneGraph,
+        _input: &String,
+    ) -> (SceneGraph, (ConstantNodeHandle, usize)) {
+        unimplemented!()
+    }
+
+    let result = graph.add_plugin(ViewportPlugin::new(MismatchedNode).unwrap());
+    assert!(matches!(result, Err(PipelineAddError::TypeMismatch { .. })));
+}
+
+#[test]
+fn test_dependent_node_in_empty_graph() {
+    let mut graph = ViewportPipeline::default();
+
+    // Try to add Node2 to an empty graph
+    let result = graph.add_plugin(ViewportPlugin::new(IncrementCounterNode {}).unwrap());
+    assert!(matches!(
+        result,
+        Err(PipelineAddError::SubsequentPluginInEmptyPipeline)
+    ));
+}

--- a/crates/viewport/tests/pipeline/main.rs
+++ b/crates/viewport/tests/pipeline/main.rs
@@ -1,0 +1,4 @@
+mod basic_operations;
+mod common;
+mod dynamic_nodes;
+mod error_handling;

--- a/crates/workspace/Cargo.toml
+++ b/crates/workspace/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "workspace"
+version = "0.1.0"
+edition = "2021"
+license = "AGPL-3.0-only"
+publish = false
+
+[dependencies]
+viewport = { path = "../viewport" }
+computegraph = { path = "../computegraph" }

--- a/crates/workspace/src/lib.rs
+++ b/crates/workspace/src/lib.rs
@@ -1,0 +1,48 @@
+#![warn(clippy::nursery)]
+#![warn(clippy::pedantic)]
+#![allow(clippy::module_name_repetitions)]
+#![allow(clippy::cognitive_complexity)]
+
+use viewport::DynamicViewportPlugin;
+
+pub struct Action();
+
+pub struct Tool {
+    pub name: String,
+    pub action: Action,
+}
+
+/// Represents a group of tools in `CADara`
+pub struct Toolgroup {
+    pub name: String,
+    pub tools: Vec<Tool>,
+}
+
+/// Represents a workspace in `CADara`
+///
+/// A workspace is a self-contained environment where users can perform specific tasks.
+/// Examples of workspaces include Design and Assemble.
+pub trait Workspace {
+    /// Returns all tools which can be invoked in this workspace.
+    ///
+    /// The tools are grouped into `Toolgroup`s, based on their functionality.
+    /// For example, all tools related to creating a new part should be grouped together,
+    /// while all tools related to creating constraints should be in a separate group.
+    fn tools(&self) -> Vec<Toolgroup>;
+
+    /// Returns a vector of `DynamicNode`s representing viewport plugins for this workspace.
+    ///
+    /// These plugins can modify or extend the viewport's functionality to enhance user experience.
+    /// The system will use the first compatible plugin from the returned vector.
+    ///
+    /// # Returns
+    ///
+    /// - A `Vec<DynamicNode>` containing viewport plugins.
+    /// - An empty vector if no plugins are required for this workspace
+    ///
+    /// # Note
+    ///
+    /// Each `DynamicNode` should represent a viewport plugin implementation.
+    // TODO: this should probably return an iterator
+    fn viewport_plugins(&self) -> Vec<DynamicViewportPlugin>;
+}


### PR DESCRIPTION
## Viewport Widget and Plugin System Implementation

This PR introduces the groundwork for a comprehensive viewport system for CADara:

1. Viewport widget implementation
2. ViewportPlugin mechanism for customizable rendering
3. Workspace definition framework
4. State support in ViewportPlugins
5. Association of Viewport with ProjectSession

The render process is split into two main stages, starting from a list of ViewportPlugins:

- Building of a SceneGraph:
  Each ViewportPlugin is responsible for building a complete renderable SceneGraph. If the next ViewportPlugin has an input parameter of the same type as the custom (application-specific) output type of the previous node, the previously given SceneGraph can be modified without completely recreating the behavior of the previous plugin.

- Rendering the final SceneGraph:
  Each SceneGraph has, by definition, update(), render(), and init_state() functions (through computegraph nodes). This state can be used for highly temporary data like the current cursor position or similar short-lived information. Mouse input will be received through update(), while render() will return an iced primitive, giving access to the screen through wgpu.

This staged abstraction to rendering will later allow for a flexible and extensible viewport system. It will enable:

- Assembly workbench to reuse the viewport plugin of modeling for an inline editing experience
- Lightweight grease pencil-like workbench for annotations
- Rendering not locked to 3D, supporting cases like 2D drawings

This approach provides a versatile foundation for various CAD workflows and visualization needs.
