### PR TITLE
feat(occara): add mesh generation and obj export

### DIFF
--- a/crates/occara/include/shape.hpp
+++ b/crates/occara/include/shape.hpp
@@ -5,10 +5,13 @@
 #include "BRepBuilderAPI_MakeWire.hxx"
 #include "BRepBuilderAPI_Transform.hxx"
 #include "BRepFilletAPI_MakeFillet.hxx"
+#include "BRepMesh_IncrementalMesh.hxx"
 #include "BRepOffsetAPI_MakeThickSolid.hxx"
 #include "BRepOffsetAPI_ThruSections.hxx"
 #include "BRepPrimAPI_MakePrism.hxx"
 #include "BRep_Tool.hxx"
+#include "IMeshData_Status.hxx"
+#include "IMeshTools_Parameters.hxx"
 #include "TopExp_Explorer.hxx"
 #include "TopoDS.hxx"
 #include "TopoDS_Edge.hxx"
@@ -31,6 +34,7 @@ struct Wire;
 struct WireBuilder;
 struct Loft;
 struct Compound;
+struct Mesh;
 
 struct Vertex {
   TopoDS_Vertex vertex;
@@ -74,6 +78,7 @@ struct Shape {
   Shape fuse(const Shape &other) const;
   static Shape cylinder(const occara::geom::PlaneAxis &axis,
                         Standard_Real radius, Standard_Real height);
+  Mesh mesh() const;
 };
 
 struct Edge {
@@ -159,6 +164,23 @@ struct Compound {
 
   void add_shape(const Shape &shape);
   Shape build();
+};
+
+struct Mesh {
+  // FIXME: This is quite inefficient but works while using autocxx.
+  // Later we should solve this by manually creating a binding for this class
+  // (and dependencies like geom::Point) using cxx. So rust code can directly
+  // use the data without copying it.
+  std::vector<size_t> indices;
+  std::vector<geom::Point> vertices;
+
+  size_t indices_size() const { return indices.size(); }
+
+  size_t vertices_size() const { return vertices.size(); }
+
+  size_t indices_at(size_t index) const { return indices[index]; }
+
+  geom::Point vertices_at(size_t index) const { return vertices[index]; }
 };
 
 } // namespace occara::shape

--- a/crates/occara/src/geom.rs
+++ b/crates/occara/src/geom.rs
@@ -11,17 +11,17 @@ impl Point {
     }
 
     #[must_use]
-    pub fn x(self) -> f64 {
+    pub fn x(&self) -> f64 {
         self.0.x()
     }
 
     #[must_use]
-    pub fn y(self) -> f64 {
+    pub fn y(&self) -> f64 {
         self.0.y()
     }
 
     #[must_use]
-    pub fn z(self) -> f64 {
+    pub fn z(&self) -> f64 {
         self.0.z()
     }
 

--- a/crates/occara/tests/meshing.rs
+++ b/crates/occara/tests/meshing.rs
@@ -1,0 +1,36 @@
+use occara::{
+    geom::{Direction, Point},
+    shape::Shape,
+};
+
+#[test]
+fn test_mesh_cylinder() {
+    let plane = Point::new(0.0, 0.0, 0.0).plane_axis_with(&Direction::z());
+    let mesh = Shape::cylinder(&plane, 1.0, 1.0).mesh();
+    let vertices = mesh.vertices();
+    let indices = mesh.indices();
+
+    // Check mesh is not empty
+    assert!(vertices.len() > 50, "Too few vertices");
+    assert!(indices.len() > 50, "Too few indices");
+
+    // Check indices are valid
+    assert!(indices.iter().all(|&i| i < vertices.len()), "Invalid index");
+
+    // Check vertices form a cylinder
+    let (min_z, max_z) = vertices
+        .iter()
+        .map(|v| v.z())
+        .fold((f64::INFINITY, f64::NEG_INFINITY), |(min, max), z| {
+            (min.min(z), max.max(z))
+        });
+
+    assert!((max_z - min_z - 1.0).abs() < 1e-6, "Incorrect height");
+
+    let max_radius = vertices
+        .iter()
+        .map(|v| (v.x().powi(2) + v.y().powi(2)).sqrt())
+        .fold(0.0, f64::max);
+
+    assert!((max_radius - 1.0).abs() < 1e-6, "Incorrect radius");
+}


### PR DESCRIPTION
This PR adds the ability to generate a mesh representation of a Shape object, allowing access to its geometry and export as an OBJ file.

This current implementation is however very inefficient due to the use of automatically generated bindings through autocxx. Manually writing bindings would accelerate this by a very large margin.

These problems will be addressed at a later point, since even this basic implementation will be enough to implement a basic modeling workspace.
