### PR TITLE
feat(computegraph): mark in/out types of run() Send

### DIFF
--- a/crates/computegraph/tests/macros.rs
+++ b/crates/computegraph/tests/macros.rs
@@ -87,8 +87,8 @@ fn test_macro_node() {
     let res = ExecutableNode::run(
         &Node6 {},
         &[
-            &(Box::new("hi".to_string()) as Box<dyn Any>),
-            &(Box::new(3_usize) as Box<dyn Any>),
+            &(Box::new("hi".to_string()) as Box<dyn Any + Send>),
+            &(Box::new(3_usize) as Box<dyn Any + Send>),
         ],
     );
     assert_eq!(res.len(), 1);
@@ -108,8 +108,8 @@ fn test_macro_node() {
     let res = ExecutableNode::run(
         &Node6 {},
         &[
-            &(Box::new("hi".to_string()) as Box<dyn Any>),
-            &(Box::new(3_usize) as Box<dyn Any>),
+            &(Box::new("hi".to_string()) as Box<dyn Any + Send>),
+            &(Box::new(3_usize) as Box<dyn Any + Send>),
         ],
     );
     assert_eq!(res.len(), 1);

--- a/crates/computegraph_macros/src/lib.rs
+++ b/crates/computegraph_macros/src/lib.rs
@@ -440,7 +440,7 @@ fn node_impl(args: TokenStream, input: TokenStream) -> TokenStream {
         }
 
         impl ::computegraph::ExecutableNode for #node_name {
-            fn run(&self, input: &[&::std::boxed::Box<dyn ::std::any::Any>]) -> Vec<::std::boxed::Box<dyn ::std::any::Any>> {
+            fn run(&self, input: &[&::std::boxed::Box<dyn ::std::any::Any + ::std::marker::Send>]) -> Vec<::std::boxed::Box<dyn ::std::any::Any + ::std::marker::Send>> {
                 let res = self.run(
                     #( input[#run_call_parameters].downcast_ref().unwrap() ),*
                 );


### PR DESCRIPTION
This allows us to use ComputationContext across different threads.
Required for storage of a computed state inside a `iced::widget::shader::Program`.