### PR TITLE
feat: implement a basic modeling workspace and viewport

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2134,7 +2134,10 @@ dependencies = [
  "computegraph",
  "glam 0.29.0",
  "iced",
+ "modeling-module",
+ "occara",
  "project",
+ "utils",
  "viewport",
  "workspace",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2100,6 +2100,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "modeling-module"
+version = "0.1.0"
+dependencies = [
+ "module",
+ "serde",
+ "uuid",
+]
+
+[[package]]
 name = "module"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2121,6 +2121,7 @@ name = "modeling-module"
 version = "0.1.0"
 dependencies = [
  "module",
+ "occara",
  "serde",
  "uuid",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -441,9 +441,9 @@ checksum = "64fa3c856b712db6612c019f14756e64e4bcea13337a6b33b696333a9eaa2d06"
 
 [[package]]
 name = "bytemuck"
-version = "1.16.1"
+version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b236fc92302c97ed75b38da1f4917b5cdda4984745740f153a5d3059e48d725e"
+checksum = "8334215b81e418a0a7bdb8ef0849474f40bb10c8b71f1c4ed315cff49f32494d"
 dependencies = [
  "bytemuck_derive",
 ]
@@ -481,8 +481,16 @@ checksum = "514de17de45fdb8dc022b1a7975556c53c86f9f0aa5f534b98977b171857c2c9"
 name = "cadara"
 version = "0.1.0"
 dependencies = [
+ "computegraph",
  "iced",
+ "modeling-module",
+ "modeling-workspace",
+ "module",
+ "project",
  "tracing-subscriber",
+ "utils",
+ "viewport",
+ "workspace",
 ]
 
 [[package]]
@@ -1289,6 +1297,15 @@ name = "glam"
 version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e05e7e6723e3455f4818c7b26e855439f7546cf617ef669d1adedb8669e5cb9"
+dependencies = [
+ "bytemuck",
+]
+
+[[package]]
+name = "glam"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c28091a37a5d09b555cb6628fd954da299b536433834f5b8e59eba78e0cbbf8a"
 dependencies = [
  "bytemuck",
 ]
@@ -2106,6 +2123,19 @@ dependencies = [
  "module",
  "serde",
  "uuid",
+]
+
+[[package]]
+name = "modeling-workspace"
+version = "0.1.0"
+dependencies = [
+ "bytemuck",
+ "computegraph",
+ "glam 0.29.0",
+ "iced",
+ "project",
+ "viewport",
+ "workspace",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,5 +10,6 @@ members = [
   "crates/cadara",
   "crates/module",
   "crates/workspace",
+  "crates/modeling-module",
 ]
 resolver = "2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ members = [
   "crates/cadara",
   "crates/module",
   "crates/workspace",
+  "crates/modeling-workspace",
   "crates/modeling-module",
 ]
 resolver = "2"

--- a/crates/cadara/Cargo.toml
+++ b/crates/cadara/Cargo.toml
@@ -7,3 +7,11 @@ license = "AGPL-3.0-only"
 [dependencies]
 iced = "0.12.1"
 tracing-subscriber = "0.3.18"
+viewport = { path = "../viewport" }
+computegraph = { path = "../computegraph" }
+workspace = { path = "../workspace" }
+modeling-workspace = { path = "../modeling-workspace" }
+modeling-module = { path = "../modeling-module" }
+module = { path = "../module" }
+project = { path = "../project" }
+utils = { path = "../utils" }

--- a/crates/cadara/src/main.rs
+++ b/crates/cadara/src/main.rs
@@ -35,7 +35,7 @@ impl iced::Sandbox for App {
         ))
         .expect("apply transaction");
         let mut viewport = viewport::Viewport::new(project);
-        let workspace = modeling_workspace::ModelingWorkspace::default();
+        let workspace = modeling_workspace::ModelingWorkspace { data_uuid };
         // TODO: this should dynamically select the first fitting plugin
         let plugin = workspace.viewport_plugins()[0].clone();
         viewport.pipeline.add_dynamic_plugin(plugin).unwrap();

--- a/crates/cadara/src/main.rs
+++ b/crates/cadara/src/main.rs
@@ -20,11 +20,20 @@ impl iced::Sandbox for App {
         let project = project::Project::new("project".to_string()).create_session();
         let doc = project.create_document();
         let doc = project.open_document(doc).unwrap();
-        let data = doc.create_data::<ModelingModule>();
-        let mut data = doc.open_data_by_uuid::<ModelingModule>(data).unwrap();
+        let data_uuid = doc.create_data::<ModelingModule>();
+        let mut data = doc.open_data_by_uuid::<ModelingModule>(data_uuid).unwrap();
 
-        data.apply(TransactionArgs::Persistent(()))
-            .expect("apply transaction");
+        data.apply(TransactionArgs::Persistent(
+            modeling_module::persistent_data::ModelingTransaction::Create(
+                modeling_module::persistent_data::Create {
+                    before: None,
+                    operation: modeling_module::operation::ModelingOperation::Sketch(
+                        modeling_module::operation::sketch::Sketch,
+                    ),
+                },
+            ),
+        ))
+        .expect("apply transaction");
         let mut viewport = viewport::Viewport::new(project);
         let workspace = modeling_workspace::ModelingWorkspace::default();
         // TODO: this should dynamically select the first fitting plugin

--- a/crates/modeling-module/Cargo.toml
+++ b/crates/modeling-module/Cargo.toml
@@ -9,3 +9,4 @@ publish = false
 module = { path = "../module" }
 uuid = { version = "1.6.1", features = ["v4", "serde"] }
 serde = { version = "1.0.195", features = ["derive", "alloc", "rc"] }
+occara = { path = "../occara" }

--- a/crates/modeling-module/Cargo.toml
+++ b/crates/modeling-module/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "modeling-module"
+version = "0.1.0"
+edition = "2021"
+license = "AGPL-3.0-only"
+publish = false
+
+[dependencies]
+module = { path = "../module" }
+uuid = { version = "1.6.1", features = ["v4", "serde"] }
+serde = { version = "1.0.195", features = ["derive", "alloc", "rc"] }

--- a/crates/modeling-module/src/lib.rs
+++ b/crates/modeling-module/src/lib.rs
@@ -3,49 +3,20 @@
 #![allow(clippy::module_name_repetitions)]
 #![allow(clippy::cognitive_complexity)]
 
-use module::{DataTransaction, Module, ReversibleDataTransaction};
-use serde::{Deserialize, Serialize};
+pub mod operation;
+pub mod persistent_data;
+mod persistent_user_data;
+mod session_data;
+mod shared_data;
 
 #[derive(Debug, Clone, Default)]
 pub struct ModelingModule {}
 
-#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
-pub struct DataSection {}
-
-impl DataTransaction for DataSection {
-    type Args = ();
-
-    type Error = ();
-
-    type Output = ();
-
-    fn apply(&mut self, _args: Self::Args) -> Result<Self::Output, Self::Error> {
-        Ok(())
-    }
-
-    fn undo_history_name(_args: &Self::Args) -> String {
-        "nothing".to_string()
-    }
-}
-
-impl ReversibleDataTransaction for DataSection {
-    type UndoData = ();
-
-    fn apply(&mut self, _args: Self::Args) -> Result<(Self::Output, Self::UndoData), Self::Error> {
-        Ok(((), ()))
-    }
-
-    fn undo(&mut self, _undo_data: Self::UndoData) {}
-}
-
-impl Module for ModelingModule {
-    type PersistentData = DataSection;
-
-    type PersistentUserData = DataSection;
-
-    type SessionData = DataSection;
-
-    type SharedData = DataSection;
+impl module::Module for ModelingModule {
+    type PersistentData = persistent_data::PersistentData;
+    type PersistentUserData = persistent_user_data::PersistentUserData;
+    type SessionData = session_data::SessionData;
+    type SharedData = shared_data::SharedData;
 
     fn name() -> String {
         "Modeling".to_string()

--- a/crates/modeling-module/src/lib.rs
+++ b/crates/modeling-module/src/lib.rs
@@ -1,0 +1,57 @@
+#![warn(clippy::nursery)]
+#![warn(clippy::pedantic)]
+#![allow(clippy::module_name_repetitions)]
+#![allow(clippy::cognitive_complexity)]
+
+use module::{DataTransaction, Module, ReversibleDataTransaction};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Default)]
+pub struct ModelingModule {}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DataSection {}
+
+impl DataTransaction for DataSection {
+    type Args = ();
+
+    type Error = ();
+
+    type Output = ();
+
+    fn apply(&mut self, _args: Self::Args) -> Result<Self::Output, Self::Error> {
+        Ok(())
+    }
+
+    fn undo_history_name(_args: &Self::Args) -> String {
+        "nothing".to_string()
+    }
+}
+
+impl ReversibleDataTransaction for DataSection {
+    type UndoData = ();
+
+    fn apply(&mut self, _args: Self::Args) -> Result<(Self::Output, Self::UndoData), Self::Error> {
+        Ok(((), ()))
+    }
+
+    fn undo(&mut self, _undo_data: Self::UndoData) {}
+}
+
+impl Module for ModelingModule {
+    type PersistentData = DataSection;
+
+    type PersistentUserData = DataSection;
+
+    type SessionData = DataSection;
+
+    type SharedData = DataSection;
+
+    fn name() -> String {
+        "Modeling".to_string()
+    }
+
+    fn uuid() -> uuid::Uuid {
+        uuid::Uuid::parse_str("04d338d9-b7a9-4f5a-b04d-724466f4058f").expect("static UUID")
+    }
+}

--- a/crates/modeling-module/src/operation.rs
+++ b/crates/modeling-module/src/operation.rs
@@ -1,0 +1,10 @@
+use serde::{Deserialize, Serialize};
+
+pub mod extrude;
+pub mod sketch;
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Hash)]
+pub enum ModelingOperation {
+    Sketch(sketch::Sketch),
+    Extrude(extrude::Extrude),
+}

--- a/crates/modeling-module/src/operation/extrude.rs
+++ b/crates/modeling-module/src/operation/extrude.rs
@@ -1,0 +1,4 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Hash)]
+pub struct Extrude;

--- a/crates/modeling-module/src/operation/sketch.rs
+++ b/crates/modeling-module/src/operation/sketch.rs
@@ -1,0 +1,4 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Hash)]
+pub struct Sketch;

--- a/crates/modeling-module/src/persistent_data.rs
+++ b/crates/modeling-module/src/persistent_data.rs
@@ -1,0 +1,101 @@
+use crate::operation::ModelingOperation;
+use module::{DataTransaction, ReversibleDataTransaction};
+use occara::{
+    geom::{Point, Vector},
+    shape::{Edge, Wire},
+};
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Step {
+    name: String,
+    operation: ModelingOperation,
+    uuid: Uuid,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PersistentData {
+    steps: Vec<Step>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Hash)]
+pub struct Create {
+    pub before: Option<Uuid>,
+    pub operation: ModelingOperation,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Hash)]
+pub enum ModelingTransaction {
+    Create(Create),
+    Update,
+    Delete,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Hash)]
+pub struct ModelingTransactionOutput {
+    uuid: Uuid,
+}
+
+impl DataTransaction for PersistentData {
+    type Args = ModelingTransaction;
+    type Error = ();
+    type Output = ModelingTransactionOutput;
+
+    fn apply(&mut self, args: Self::Args) -> Result<Self::Output, Self::Error> {
+        ReversibleDataTransaction::apply(self, args).map(|a| a.0)
+    }
+
+    fn undo_history_name(_args: &Self::Args) -> String {
+        String::new()
+    }
+}
+
+impl ReversibleDataTransaction for PersistentData {
+    type UndoData = ();
+
+    fn apply(&mut self, args: Self::Args) -> Result<(Self::Output, Self::UndoData), Self::Error> {
+        match args {
+            ModelingTransaction::Create(c) => {
+                let uuid = Uuid::new_v4();
+                self.steps.push(Step {
+                    name: "new operation".to_string(),
+                    operation: c.operation,
+                    uuid,
+                });
+                Ok((ModelingTransactionOutput { uuid }, ()))
+            }
+            ModelingTransaction::Update => todo!(),
+            ModelingTransaction::Delete => todo!(),
+        }
+    }
+
+    fn undo(&mut self, _undo_data: Self::UndoData) {
+        unimplemented!("not supported")
+    }
+}
+
+impl PersistentData {
+    #[must_use]
+    pub fn shape(&self) -> occara::shape::Shape {
+        let wire = {
+            let p1 = Point::new(0.0, 0.0, 0.0);
+            let p2 = Point::new(0.0, 1.0, 0.0);
+            let p3 = Point::new(1.0, 1.0, 0.0);
+            let p4 = Point::new(1.0, 0.0, 0.0);
+            Wire::new(&[
+                &Edge::line(&p1, &p2),
+                &Edge::line(&p2, &p3),
+                &Edge::line(&p3, &p4),
+                &Edge::line(&p4, &p1),
+            ])
+        };
+        let b = wire.face().extrude(&Vector::new(0.0, 0.0, 1.0));
+
+        let mut f = b.fillet();
+        for e in b.edges() {
+            f.add(0.2, &e);
+        }
+        f.build()
+    }
+}

--- a/crates/modeling-module/src/persistent_user_data.rs
+++ b/crates/modeling-module/src/persistent_user_data.rs
@@ -1,0 +1,29 @@
+use module::{DataTransaction, ReversibleDataTransaction};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PersistentUserData {}
+
+impl DataTransaction for PersistentUserData {
+    type Args = ();
+    type Error = ();
+    type Output = ();
+
+    fn apply(&mut self, _args: Self::Args) -> Result<Self::Output, Self::Error> {
+        Ok(())
+    }
+
+    fn undo_history_name(_args: &Self::Args) -> String {
+        String::new()
+    }
+}
+
+impl ReversibleDataTransaction for PersistentUserData {
+    type UndoData = ();
+
+    fn apply(&mut self, _args: Self::Args) -> Result<(Self::Output, Self::UndoData), Self::Error> {
+        Ok(((), ()))
+    }
+
+    fn undo(&mut self, _undo_data: Self::UndoData) {}
+}

--- a/crates/modeling-module/src/session_data.rs
+++ b/crates/modeling-module/src/session_data.rs
@@ -1,0 +1,29 @@
+use module::{DataTransaction, ReversibleDataTransaction};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SessionData {}
+
+impl DataTransaction for SessionData {
+    type Args = ();
+    type Error = ();
+    type Output = ();
+
+    fn apply(&mut self, _args: Self::Args) -> Result<Self::Output, Self::Error> {
+        Ok(())
+    }
+
+    fn undo_history_name(_args: &Self::Args) -> String {
+        String::new()
+    }
+}
+
+impl ReversibleDataTransaction for SessionData {
+    type UndoData = ();
+
+    fn apply(&mut self, _args: Self::Args) -> Result<(Self::Output, Self::UndoData), Self::Error> {
+        Ok(((), ()))
+    }
+
+    fn undo(&mut self, _undo_data: Self::UndoData) {}
+}

--- a/crates/modeling-module/src/shared_data.rs
+++ b/crates/modeling-module/src/shared_data.rs
@@ -1,0 +1,29 @@
+use module::{DataTransaction, ReversibleDataTransaction};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SharedData {}
+
+impl DataTransaction for SharedData {
+    type Args = ();
+    type Error = ();
+    type Output = ();
+
+    fn apply(&mut self, _args: Self::Args) -> Result<Self::Output, Self::Error> {
+        Ok(())
+    }
+
+    fn undo_history_name(_args: &Self::Args) -> String {
+        String::new()
+    }
+}
+
+impl ReversibleDataTransaction for SharedData {
+    type UndoData = ();
+
+    fn apply(&mut self, _args: Self::Args) -> Result<(Self::Output, Self::UndoData), Self::Error> {
+        Ok(((), ()))
+    }
+
+    fn undo(&mut self, _undo_data: Self::UndoData) {}
+}

--- a/crates/modeling-workspace/Cargo.toml
+++ b/crates/modeling-workspace/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "modeling-workspace"
+version = "0.1.0"
+edition = "2021"
+license = "AGPL-3.0-only"
+publish = false
+
+[dependencies]
+workspace = { path = "../workspace" }
+viewport = { path = "../viewport" }
+computegraph = { path = "../computegraph" }
+project = { path = "../project" }
+iced = { version = "0.12.1", features = ["advanced"] }
+bytemuck = "1.17.0"
+glam = { version = "0.29.0", features = ["bytemuck"] }

--- a/crates/modeling-workspace/Cargo.toml
+++ b/crates/modeling-workspace/Cargo.toml
@@ -9,7 +9,10 @@ publish = false
 workspace = { path = "../workspace" }
 viewport = { path = "../viewport" }
 computegraph = { path = "../computegraph" }
+modeling-module = { path = "../modeling-module" }
+occara = { path = "../occara" }
 project = { path = "../project" }
 iced = { version = "0.12.1", features = ["advanced"] }
 bytemuck = "1.17.0"
+utils = { path = "../utils" }
 glam = { version = "0.29.0", features = ["bytemuck"] }

--- a/crates/modeling-workspace/src/lib.rs
+++ b/crates/modeling-workspace/src/lib.rs
@@ -1,0 +1,31 @@
+#![warn(clippy::nursery)]
+#![warn(clippy::pedantic)]
+#![allow(clippy::module_name_repetitions)]
+#![allow(clippy::cognitive_complexity)]
+#![allow(clippy::cast_possible_truncation)]
+
+mod viewport;
+
+use ::viewport::DynamicViewportPlugin;
+
+#[derive(Debug, Default)]
+pub struct ModelingWorkspace {}
+
+impl workspace::Workspace for ModelingWorkspace {
+    fn tools(&self) -> Vec<workspace::Toolgroup> {
+        use workspace::{Action, Tool, Toolgroup};
+        vec![Toolgroup {
+            name: "Some Group".to_string(),
+            tools: vec![Tool {
+                name: "Some Tool".to_string(),
+                action: Action(),
+            }],
+        }]
+    }
+
+    fn viewport_plugins(&self) -> Vec<DynamicViewportPlugin> {
+        vec![
+            DynamicViewportPlugin::new(viewport::ModelingViewportPlugin::default().into()).unwrap(),
+        ]
+    }
+}

--- a/crates/modeling-workspace/src/lib.rs
+++ b/crates/modeling-workspace/src/lib.rs
@@ -8,8 +8,10 @@ mod viewport;
 
 use ::viewport::DynamicViewportPlugin;
 
-#[derive(Debug, Default)]
-pub struct ModelingWorkspace {}
+#[derive(Debug)]
+pub struct ModelingWorkspace {
+    pub data_uuid: project::data::DataUuid,
+}
 
 impl workspace::Workspace for ModelingWorkspace {
     fn tools(&self) -> Vec<workspace::Toolgroup> {
@@ -24,8 +26,12 @@ impl workspace::Workspace for ModelingWorkspace {
     }
 
     fn viewport_plugins(&self) -> Vec<DynamicViewportPlugin> {
-        vec![
-            DynamicViewportPlugin::new(viewport::ModelingViewportPlugin::default().into()).unwrap(),
-        ]
+        vec![DynamicViewportPlugin::new(
+            viewport::ModelingViewportPlugin {
+                data_uuid: self.data_uuid,
+            }
+            .into(),
+        )
+        .unwrap()]
     }
 }

--- a/crates/modeling-workspace/src/viewport.rs
+++ b/crates/modeling-workspace/src/viewport.rs
@@ -1,6 +1,7 @@
 use computegraph::{node, ComputeGraph};
 use viewport::{RenderNodePorts, SceneGraphBuilder, UpdateNodePorts};
 
+mod camera;
 mod rendering;
 mod scene_nodes;
 mod state;

--- a/crates/modeling-workspace/src/viewport.rs
+++ b/crates/modeling-workspace/src/viewport.rs
@@ -8,8 +8,10 @@ mod state;
 #[derive(Clone, Debug)]
 pub struct ModelingViewportPluginOutput {}
 
-#[derive(Clone, Default, Debug)]
-pub struct ModelingViewportPlugin {}
+#[derive(Clone, Debug)]
+pub struct ModelingViewportPlugin {
+    pub data_uuid: project::data::DataUuid,
+}
 
 #[node(ModelingViewportPlugin -> (scene, output))]
 fn run(
@@ -18,10 +20,20 @@ fn run(
 ) -> (viewport::SceneGraph, ModelingViewportPluginOutput) {
     let mut graph = ComputeGraph::new();
     let render_node = graph
-        .add_node(scene_nodes::RenderNode {}, "render".to_string())
+        .add_node(
+            scene_nodes::RenderNode {
+                data_uuid: self.data_uuid,
+            },
+            "render".to_string(),
+        )
         .unwrap();
     let update_node = graph
-        .add_node(scene_nodes::UpdateStateNode {}, "update".to_string())
+        .add_node(
+            scene_nodes::UpdateStateNode {
+                data_uuid: self.data_uuid,
+            },
+            "update".to_string(),
+        )
         .unwrap();
     let init_node = graph
         .add_node(scene_nodes::InitStateNode {}, "init".to_string())

--- a/crates/modeling-workspace/src/viewport.rs
+++ b/crates/modeling-workspace/src/viewport.rs
@@ -1,0 +1,47 @@
+use computegraph::{node, ComputeGraph};
+use viewport::{RenderNodePorts, SceneGraphBuilder, UpdateNodePorts};
+
+mod rendering;
+mod scene_nodes;
+mod state;
+
+#[derive(Clone, Debug)]
+pub struct ModelingViewportPluginOutput {}
+
+#[derive(Clone, Default, Debug)]
+pub struct ModelingViewportPlugin {}
+
+#[node(ModelingViewportPlugin -> (scene, output))]
+fn run(
+    &self,
+    _project: &project::ProjectSession,
+) -> (viewport::SceneGraph, ModelingViewportPluginOutput) {
+    let mut graph = ComputeGraph::new();
+    let render_node = graph
+        .add_node(scene_nodes::RenderNode {}, "render".to_string())
+        .unwrap();
+    let update_node = graph
+        .add_node(scene_nodes::UpdateStateNode {}, "update".to_string())
+        .unwrap();
+    let init_node = graph
+        .add_node(scene_nodes::InitStateNode {}, "init".to_string())
+        .unwrap();
+
+    (
+        SceneGraphBuilder {
+            graph,
+            initial_state: init_node.output(),
+            render_node: RenderNodePorts {
+                state_in: render_node.input_state(),
+                primitive_out: render_node.output(),
+            },
+            update_node: UpdateNodePorts {
+                event_in: update_node.input_event(),
+                state_in: update_node.input_state(),
+                state_out: update_node.output(),
+            },
+        }
+        .into(),
+        ModelingViewportPluginOutput {},
+    )
+}

--- a/crates/modeling-workspace/src/viewport/camera.rs
+++ b/crates/modeling-workspace/src/viewport/camera.rs
@@ -1,0 +1,88 @@
+use glam::{Mat4, Vec3};
+
+#[derive(Debug, Clone)]
+pub struct Camera {
+    pub pos: Vec3,
+    pub yaw: f32,
+    pub pitch: f32,
+    pub fov: f32,
+    pub aspect: f32,
+    pub near: f32,
+    pub far: f32,
+}
+
+impl Default for Camera {
+    fn default() -> Self {
+        Self {
+            pos: Vec3::ZERO,
+            yaw: 0.0,
+            pitch: 0.0,
+            fov: 60.0_f32.to_radians(),
+            aspect: 1.0,
+            near: 0.1,
+            far: 1000.0,
+        }
+    }
+}
+
+impl Camera {
+    pub fn set_aspect(&mut self, width: f32, height: f32) {
+        self.aspect = width / height;
+    }
+
+    pub fn front(&self) -> Vec3 {
+        let (sy, cy) = self.yaw.sin_cos();
+        let (sp, cp) = self.pitch.sin_cos();
+        Vec3::new(cy * cp, sp, sy * cp).normalize()
+    }
+
+    pub fn right(&self) -> Vec3 {
+        self.front().cross(Vec3::Y).normalize()
+    }
+
+    pub fn up(&self) -> Vec3 {
+        self.front().cross(self.right()).normalize()
+    }
+
+    pub fn view_matrix(&self) -> Mat4 {
+        Mat4::look_to_rh(self.pos, self.front(), Vec3::Y)
+    }
+
+    pub fn projection_matrix(&self) -> Mat4 {
+        Mat4::perspective_rh(self.fov, self.aspect, self.near, self.far)
+    }
+
+    pub fn view_projection_matrix(&self) -> Mat4 {
+        self.projection_matrix() * self.view_matrix()
+    }
+
+    pub fn move_forward(&mut self, distance: f32) {
+        self.pos += self.front() * distance;
+    }
+
+    pub fn pan(&mut self, x: f32, y: f32) {
+        self.pos += self.right() * x + self.up() * y;
+    }
+
+    pub fn rotate(&mut self, yaw_delta: f32, pitch_delta: f32) {
+        self.yaw += yaw_delta;
+        self.pitch += pitch_delta;
+        self.pitch = self
+            .pitch
+            .clamp(-89.0_f32.to_radians(), 89.0_f32.to_radians());
+    }
+}
+
+#[derive(Copy, Clone, Debug, bytemuck::Pod, bytemuck::Zeroable)]
+#[repr(C)]
+pub struct CameraUniform {
+    pub view_proj: Mat4,
+}
+
+impl From<&Camera> for CameraUniform {
+    fn from(camera: &Camera) -> Self {
+        Self {
+            view_proj: camera.view_projection_matrix(),
+        }
+    }
+}

--- a/crates/modeling-workspace/src/viewport/rendering.rs
+++ b/crates/modeling-workspace/src/viewport/rendering.rs
@@ -1,0 +1,188 @@
+use iced::widget::shader::{self, wgpu};
+
+use super::state::ViewportState;
+
+#[derive(Debug)]
+pub struct RenderPrimitive {
+    pub state: ViewportState,
+}
+
+#[derive(Copy, Clone, Debug, bytemuck::Pod, bytemuck::Zeroable)]
+#[repr(C)]
+pub struct CameraUniform {
+    pub view_pos: glam::Vec2,
+}
+
+impl shader::Primitive for RenderPrimitive {
+    fn prepare(
+        &self,
+        format: wgpu::TextureFormat,
+        device: &wgpu::Device,
+        queue: &wgpu::Queue,
+        bounds: iced::Rectangle,
+        target_size: iced::Size<u32>,
+        scale_factor: f32,
+        storage: &mut shader::Storage,
+    ) {
+        if !storage.has::<RenderPipeline>() {
+            storage.store(RenderPipeline::new(device, queue, format, target_size));
+        }
+        let pipeline = storage.get_mut::<RenderPipeline>().unwrap();
+        pipeline.update(device, queue, bounds, target_size, scale_factor, self);
+    }
+
+    fn render(
+        &self,
+        storage: &shader::Storage,
+        target: &wgpu::TextureView,
+        _target_size: iced::Size<u32>,
+        viewport: iced::Rectangle<u32>,
+        encoder: &mut wgpu::CommandEncoder,
+    ) {
+        let pipeline = storage.get::<RenderPipeline>().unwrap();
+
+        pipeline.render(encoder, target, viewport);
+    }
+}
+
+#[derive(Debug)]
+struct RenderPipeline {
+    pipeline: wgpu::RenderPipeline,
+    camera_bind_group: wgpu::BindGroup,
+    uniforms: wgpu::Buffer,
+}
+
+impl RenderPipeline {
+    fn new(
+        device: &wgpu::Device,
+        _queue: &wgpu::Queue,
+        format: wgpu::TextureFormat,
+        _target_size: iced::Size<u32>,
+    ) -> Self {
+        let shader = device.create_shader_module(wgpu::ShaderModuleDescriptor {
+            label: None,
+            source: wgpu::ShaderSource::Wgsl(std::borrow::Cow::Borrowed(include_str!(
+                "shader.wgsl"
+            ))),
+        });
+
+        let camera_bind_group_layout =
+            device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+                label: Some("camera_bind_group_layout"),
+                entries: &[wgpu::BindGroupLayoutEntry {
+                    binding: 0,
+                    visibility: wgpu::ShaderStages::VERTEX,
+                    ty: wgpu::BindingType::Buffer {
+                        ty: wgpu::BufferBindingType::Uniform,
+                        has_dynamic_offset: false,
+                        min_binding_size: None,
+                    },
+                    count: None,
+                }],
+            });
+        let uniforms = device.create_buffer(&wgpu::BufferDescriptor {
+            label: None,
+            size: std::mem::size_of::<CameraUniform>() as u64,
+            usage: wgpu::BufferUsages::UNIFORM | wgpu::BufferUsages::COPY_DST,
+            mapped_at_creation: false,
+        });
+
+        let camera_bind_group = device.create_bind_group(&wgpu::BindGroupDescriptor {
+            label: None,
+            layout: &camera_bind_group_layout,
+            entries: &[wgpu::BindGroupEntry {
+                binding: 0,
+                resource: uniforms.as_entire_binding(),
+            }],
+        });
+
+        let pipeline_layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
+            label: None,
+            bind_group_layouts: &[&camera_bind_group_layout],
+            push_constant_ranges: &[],
+        });
+
+        let pipeline = device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
+            label: None,
+            layout: Some(&pipeline_layout),
+            vertex: wgpu::VertexState {
+                module: &shader,
+                entry_point: "vs_main",
+                buffers: &[],
+            },
+            fragment: Some(wgpu::FragmentState {
+                module: &shader,
+                entry_point: "fs_main",
+                targets: &[Some(wgpu::ColorTargetState {
+                    format,
+                    blend: None,
+                    write_mask: wgpu::ColorWrites::ALL,
+                })],
+            }),
+            primitive: wgpu::PrimitiveState::default(),
+            depth_stencil: None,
+            multisample: wgpu::MultisampleState::default(),
+            multiview: None,
+        });
+
+        Self {
+            pipeline,
+            camera_bind_group,
+            uniforms,
+        }
+    }
+
+    fn update(
+        &self,
+        _device: &wgpu::Device,
+        queue: &wgpu::Queue,
+        bounds: iced::Rectangle,
+        _target_size: iced::Size<u32>,
+        _scale_factor: f32,
+        primitive: &RenderPrimitive,
+    ) {
+        let p = primitive.state.camera_pos;
+        let x = ((p.x - bounds.x) / bounds.width).mul_add(2.0, -1.0);
+        let y = ((p.y - bounds.y) / bounds.height).mul_add(-2.0, 1.0);
+        let uniforms = CameraUniform {
+            view_pos: glam::Vec2 { x, y },
+        };
+        queue.write_buffer(&self.uniforms, 0, bytemuck::cast_slice(&[uniforms]));
+    }
+
+    fn render(
+        &self,
+        encoder: &mut wgpu::CommandEncoder,
+        target: &wgpu::TextureView,
+        viewport: iced::Rectangle<u32>,
+    ) {
+        let mut render_pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+            label: None,
+            color_attachments: &[Some(wgpu::RenderPassColorAttachment {
+                view: target,
+                resolve_target: None,
+                ops: wgpu::Operations {
+                    load: wgpu::LoadOp::Load,
+                    store: wgpu::StoreOp::Store,
+                },
+            })],
+            depth_stencil_attachment: None,
+            timestamp_writes: None,
+            occlusion_query_set: None,
+        });
+
+        render_pass.set_pipeline(&self.pipeline);
+
+        #[allow(clippy::cast_precision_loss)]
+        render_pass.set_viewport(
+            viewport.x as f32,
+            viewport.y as f32,
+            viewport.width as f32,
+            viewport.height as f32,
+            0.0,
+            1.0,
+        );
+        render_pass.set_bind_group(0, &self.camera_bind_group, &[]);
+        render_pass.draw(0..3, 0..1);
+    }
+}

--- a/crates/modeling-workspace/src/viewport/scene_nodes.rs
+++ b/crates/modeling-workspace/src/viewport/scene_nodes.rs
@@ -1,0 +1,59 @@
+use computegraph::node;
+use iced::widget::shader;
+use viewport::ViewportEvent;
+
+use super::{rendering::RenderPrimitive, state::ViewportState};
+
+#[derive(Clone, Debug)]
+pub struct RenderNode {}
+
+#[node(RenderNode)]
+fn run(
+    &self,
+    state: &ViewportState,
+    _project: &project::ProjectSession,
+) -> Box<dyn shader::Primitive> {
+    Box::new(RenderPrimitive {
+        state: (*state).clone(),
+    })
+}
+
+#[derive(Clone, Debug)]
+pub struct UpdateStateNode {}
+
+#[node(UpdateStateNode)]
+fn run(
+    &self,
+    event: &ViewportEvent,
+    state: &ViewportState,
+    _project: &project::ProjectSession,
+) -> ViewportState {
+    let mut state = (*state).clone();
+    if let shader::Event::Mouse(m) = event.event {
+        match m {
+            iced::mouse::Event::ButtonPressed(iced::mouse::Button::Left) => {
+                state.l_button_pressed = true;
+            }
+            iced::mouse::Event::ButtonReleased(iced::mouse::Button::Left) => {
+                state.l_button_pressed = false;
+            }
+            iced::mouse::Event::CursorMoved { position } => {
+                if state.l_button_pressed {
+                    let c = position - state.cursor_position;
+                    state.camera_pos += glam::Vec2 { x: c.x, y: c.y };
+                }
+                state.cursor_position = position;
+            }
+            _ => {}
+        }
+    }
+    state
+}
+
+#[derive(Clone, Debug)]
+pub struct InitStateNode {}
+
+#[node(InitStateNode)]
+fn run(&self) -> ViewportState {
+    ViewportState::default()
+}

--- a/crates/modeling-workspace/src/viewport/scene_nodes.rs
+++ b/crates/modeling-workspace/src/viewport/scene_nodes.rs
@@ -13,10 +13,15 @@ pub struct RenderNode {
 fn run(
     &self,
     state: &ViewportState,
-    _project: &project::ProjectSession,
+    project: &project::ProjectSession,
 ) -> Box<dyn shader::Primitive> {
+    let data_session: project::data::DataSession<modeling_module::ModelingModule> =
+        project.open_data(self.data_uuid).unwrap();
+    let shape = data_session.snapshot().persistent.shape();
+    let mesh = shape.mesh();
     Box::new(RenderPrimitive {
         state: (*state).clone(),
+        mesh,
     })
 }
 
@@ -33,6 +38,8 @@ fn run(
     project: &project::ProjectSession,
 ) -> ViewportState {
     let mut state = (*state).clone();
+    let mut _data_session: project::data::DataSession<modeling_module::ModelingModule> =
+        project.open_data(self.data_uuid).unwrap();
     if let shader::Event::Mouse(m) = event.event {
         match m {
             iced::mouse::Event::ButtonPressed(iced::mouse::Button::Left) => {
@@ -41,13 +48,26 @@ fn run(
             iced::mouse::Event::ButtonReleased(iced::mouse::Button::Left) => {
                 state.l_button_pressed = false;
             }
+            iced::mouse::Event::ButtonPressed(iced::mouse::Button::Right) => {
+                state.r_button_pressed = true;
+            }
+            iced::mouse::Event::ButtonReleased(iced::mouse::Button::Right) => {
+                state.r_button_pressed = false;
+            }
             iced::mouse::Event::CursorMoved { position } => {
                 if state.l_button_pressed {
+                    let c = (position - state.cursor_position) * -0.01;
+                    state.camera.pan(c.x, c.y);
+                } else if state.r_button_pressed {
                     let c = position - state.cursor_position;
-                    state.camera_pos += glam::Vec2 { x: c.x, y: c.y };
+                    state.camera.rotate(-c.x * 0.003, c.y * 0.003);
                 }
                 state.cursor_position = position;
             }
+            iced::mouse::Event::WheelScrolled { delta } => match delta {
+                iced::mouse::ScrollDelta::Lines { x: _, y } => state.camera.move_forward(y * 0.08),
+                iced::mouse::ScrollDelta::Pixels { x: _, y } => state.camera.move_forward(y * 0.01),
+            },
             _ => {}
         }
     }

--- a/crates/modeling-workspace/src/viewport/scene_nodes.rs
+++ b/crates/modeling-workspace/src/viewport/scene_nodes.rs
@@ -5,7 +5,9 @@ use viewport::ViewportEvent;
 use super::{rendering::RenderPrimitive, state::ViewportState};
 
 #[derive(Clone, Debug)]
-pub struct RenderNode {}
+pub struct RenderNode {
+    pub data_uuid: project::data::DataUuid,
+}
 
 #[node(RenderNode)]
 fn run(
@@ -19,14 +21,16 @@ fn run(
 }
 
 #[derive(Clone, Debug)]
-pub struct UpdateStateNode {}
+pub struct UpdateStateNode {
+    pub data_uuid: project::data::DataUuid,
+}
 
 #[node(UpdateStateNode)]
 fn run(
     &self,
     event: &ViewportEvent,
     state: &ViewportState,
-    _project: &project::ProjectSession,
+    project: &project::ProjectSession,
 ) -> ViewportState {
     let mut state = (*state).clone();
     if let shader::Event::Mouse(m) = event.event {

--- a/crates/modeling-workspace/src/viewport/shader.wgsl
+++ b/crates/modeling-workspace/src/viewport/shader.wgsl
@@ -1,25 +1,44 @@
 struct CameraUniform {
-    view_pos: vec2<f32>,
+    view_proj: mat4x4<f32>,
 }
 
-@group(0) @binding(0) var<uniform> camera: CameraUniform;
+@group(0) @binding(0)
+var<uniform> camera: CameraUniform;
+
 struct VertexOutput {
     @builtin(position) clip_position: vec4<f32>,
+    @location(0) world_position: vec3<f32>,
 };
 
-@vertex
-fn vs_main(@builtin(vertex_index) in_vertex_index: u32) -> VertexOutput {
-    let pos = vec2<f32>(
-        f32(1 - i32(in_vertex_index & 1u) * 2),
-        f32(1 - i32(in_vertex_index >> 1u) * 2)
-    ) + camera.view_pos;
+struct Vertex {
+    @location(0) pos: vec3<f32>,
+}
 
+@vertex
+fn vs_main(vertex: Vertex) -> VertexOutput {
     var out: VertexOutput;
-    out.clip_position = vec4<f32>(pos, 0.0, 1.0);
+
+    // Transform the vertex position to world space
+    let world_pos = vertex.pos;
+
+    // Transform the world position to clip space
+    out.clip_position = camera.view_proj * vec4<f32>(world_pos, 1.0);
+
+    // Pass the world position to the fragment shader
+    out.world_position = world_pos;
+
     return out;
 }
 
 @fragment
 fn fs_main(in: VertexOutput) -> @location(0) vec4<f32> {
-    return vec4<f32>(0.0, 0.0, 1.0, 1.0);
+    // Calculate the normal using dpdx and dpdy on the world position
+    let dx = dpdx(in.world_position);
+    let dy = dpdy(in.world_position);
+    let normal = normalize(cross(dy, dx));
+
+    // Map the normal to color space
+    let color = normal * 0.5 + 0.5;
+
+    return vec4<f32>(color, 1.0);
 }

--- a/crates/modeling-workspace/src/viewport/shader.wgsl
+++ b/crates/modeling-workspace/src/viewport/shader.wgsl
@@ -1,0 +1,25 @@
+struct CameraUniform {
+    view_pos: vec2<f32>,
+}
+
+@group(0) @binding(0) var<uniform> camera: CameraUniform;
+struct VertexOutput {
+    @builtin(position) clip_position: vec4<f32>,
+};
+
+@vertex
+fn vs_main(@builtin(vertex_index) in_vertex_index: u32) -> VertexOutput {
+    let pos = vec2<f32>(
+        f32(1 - i32(in_vertex_index & 1u) * 2),
+        f32(1 - i32(in_vertex_index >> 1u) * 2)
+    ) + camera.view_pos;
+
+    var out: VertexOutput;
+    out.clip_position = vec4<f32>(pos, 0.0, 1.0);
+    return out;
+}
+
+@fragment
+fn fs_main(in: VertexOutput) -> @location(0) vec4<f32> {
+    return vec4<f32>(0.0, 0.0, 1.0, 1.0);
+}

--- a/crates/modeling-workspace/src/viewport/state.rs
+++ b/crates/modeling-workspace/src/viewport/state.rs
@@ -1,6 +1,9 @@
+use super::camera::Camera;
+
 #[derive(Default, Clone, Debug)]
 pub struct ViewportState {
     pub l_button_pressed: bool,
+    pub r_button_pressed: bool,
     pub cursor_position: iced::Point,
-    pub camera_pos: glam::Vec2,
+    pub camera: Camera,
 }

--- a/crates/modeling-workspace/src/viewport/state.rs
+++ b/crates/modeling-workspace/src/viewport/state.rs
@@ -1,0 +1,6 @@
+#[derive(Default, Clone, Debug)]
+pub struct ViewportState {
+    pub l_button_pressed: bool,
+    pub cursor_position: iced::Point,
+    pub camera_pos: glam::Vec2,
+}


### PR DESCRIPTION
This PR implements the ground work of the future modeling workspace by:
- Creating a new modeling-module, that can return a rounded cube for testing purposes
- Adding a new modeling-workspace, that retrieves the model, meshes it and displays it inside a viewport widget.
- Adding a viewport widget to test this system.