### PR TITLE
feat(occara): various improvements and fixes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,4 +39,4 @@ jobs:
       - name: Build
         run: cargo build --verbose --workspace --all-features
       - name: Run tests
-        run: cargo test --verbose --workspace --all-features
+        run: cargo test --verbose --workspace --all-features -- --include-ignored

--- a/crates/occara/cpp/geom.cpp
+++ b/crates/occara/cpp/geom.cpp
@@ -54,6 +54,13 @@ Direction Direction::create(Standard_Real x, Standard_Real y, Standard_Real z) {
 
 Direction Direction::clone() const { return *this; }
 
+void Direction::get_components(Standard_Real &x, Standard_Real &y,
+                               Standard_Real &z) const {
+  x = direction.X();
+  y = direction.Y();
+  z = direction.Z();
+}
+
 // Direction2D
 
 Direction2D Direction2D::create(Standard_Real x, Standard_Real y) {
@@ -61,6 +68,11 @@ Direction2D Direction2D::create(Standard_Real x, Standard_Real y) {
 }
 
 Direction2D Direction2D::clone() const { return *this; }
+
+void Direction2D::get_components(Standard_Real &x, Standard_Real &y) const {
+  x = direction.X();
+  y = direction.Y();
+}
 
 // Axis
 
@@ -70,6 +82,10 @@ Axis Axis::create(const Point &origin, const Direction &direction) {
 
 Axis Axis::clone() const { return *this; }
 
+Point Axis::location() const { return Point{axis.Location()}; }
+
+Direction Axis::direction() const { return Direction{axis.Direction()}; }
+
 // Axis2D
 
 Axis2D Axis2D::create(const Point2D &origin, const Direction2D &direction) {
@@ -77,6 +93,10 @@ Axis2D Axis2D::create(const Point2D &origin, const Direction2D &direction) {
 }
 
 Axis2D Axis2D::clone() const { return *this; }
+
+Point2D Axis2D::location() const { return Point2D{axis.Location()}; }
+
+Direction2D Axis2D::direction() const { return Direction2D{axis.Direction()}; }
 
 // PlaneAxis
 
@@ -86,6 +106,10 @@ PlaneAxis PlaneAxis::create(const Point &origin, const Direction &direction) {
 
 PlaneAxis PlaneAxis::clone() const { return *this; }
 
+Point PlaneAxis::location() const { return Point{axis.Location()}; }
+
+Direction PlaneAxis::direction() const { return Direction{axis.Direction()}; }
+
 // SpaceAxis
 
 SpaceAxis SpaceAxis::create(const Point &origin, const Direction &direction) {
@@ -93,6 +117,10 @@ SpaceAxis SpaceAxis::create(const Point &origin, const Direction &direction) {
 }
 
 SpaceAxis SpaceAxis::clone() const { return *this; }
+
+Point SpaceAxis::location() const { return Point{axis.Location()}; }
+
+Direction SpaceAxis::direction() const { return Direction{axis.Direction()}; }
 
 // TrimmedCurve
 

--- a/crates/occara/cpp/shape.cpp
+++ b/crates/occara/cpp/shape.cpp
@@ -130,6 +130,8 @@ ShapeType Shape::shape_type() const {
 
 Standard_Boolean Shape::is_null() const { return shape.IsNull(); }
 
+Standard_Boolean Shape::is_closed() const { return shape.Closed(); }
+
 // Edge
 
 Edge Edge::from_curve(const occara::geom::TrimmedCurve &curve) {

--- a/crates/occara/cpp/shape.cpp
+++ b/crates/occara/cpp/shape.cpp
@@ -86,7 +86,6 @@ Mesh Shape::mesh() const {
 
   // Perform meshing
   BRepMesh_IncrementalMesh mesher(shape, meshParams);
-  std::cout << "Mesh called\n";
 
   // Collect vertices and indices
   std::vector<geom::Point> vertices;
@@ -95,13 +94,11 @@ Mesh Shape::mesh() const {
   TopExp_Explorer faceExplorer(shape, TopAbs_FACE);
   for (; faceExplorer.More(); faceExplorer.Next()) {
     TopoDS_Face face = TopoDS::Face(faceExplorer.Current());
-    std::cerr << "Face\n";
     TopLoc_Location loc;
     Handle(Poly_Triangulation) triangulation =
         BRep_Tool::Triangulation(face, loc);
 
     if (triangulation.IsNull()) {
-      std::cerr << "Triangulation is null for face\n";
       continue;
     }
 

--- a/crates/occara/cpp/shape.cpp
+++ b/crates/occara/cpp/shape.cpp
@@ -1,4 +1,6 @@
 #include "shape.hpp"
+#include "BRepAlgoAPI_Common.hxx"
+#include "BRepAlgoAPI_Cut.hxx"
 #include "BRepAlgoAPI_Fuse.hxx"
 #include "BRepPrimAPI_MakeCylinder.hxx"
 #include <BRepGProp.hxx>
@@ -64,6 +66,14 @@ FilletBuilder Shape::fillet() const {
 
 Shape Shape::fuse(const Shape &other) const {
   return Shape{BRepAlgoAPI_Fuse(shape, other.shape).Shape()};
+}
+
+Shape Shape::subtract(const Shape &other) const {
+  return Shape{BRepAlgoAPI_Cut(shape, other.shape).Shape()};
+}
+
+Shape Shape::intersect(const Shape &other) const {
+  return Shape{BRepAlgoAPI_Common(shape, other.shape).Shape()};
 }
 
 Shape Shape::cylinder(const occara::geom::PlaneAxis &axis, Standard_Real radius,

--- a/crates/occara/cpp/shape.cpp
+++ b/crates/occara/cpp/shape.cpp
@@ -124,6 +124,10 @@ Mesh Shape::mesh() const {
   };
 }
 
+ShapeType Shape::shape_type() const {
+  return static_cast<ShapeType>(shape.ShapeType());
+}
+
 // Edge
 
 Edge Edge::from_curve(const occara::geom::TrimmedCurve &curve) {

--- a/crates/occara/cpp/shape.cpp
+++ b/crates/occara/cpp/shape.cpp
@@ -1,7 +1,9 @@
 #include "shape.hpp"
 #include "BRepAlgoAPI_Fuse.hxx"
 #include "BRepPrimAPI_MakeCylinder.hxx"
+#include <BRepGProp.hxx>
 #include <BRepLib.hxx>
+#include <GProp_GProps.hxx>
 
 namespace occara::shape {
 
@@ -131,6 +133,12 @@ ShapeType Shape::shape_type() const {
 Standard_Boolean Shape::is_null() const { return shape.IsNull(); }
 
 Standard_Boolean Shape::is_closed() const { return shape.Closed(); }
+
+Standard_Real Shape::mass() const {
+  GProp_GProps props;
+  BRepGProp::VolumeProperties(shape, props);
+  return props.Mass();
+}
 
 // Edge
 

--- a/crates/occara/cpp/shape.cpp
+++ b/crates/occara/cpp/shape.cpp
@@ -128,6 +128,8 @@ ShapeType Shape::shape_type() const {
   return static_cast<ShapeType>(shape.ShapeType());
 }
 
+Standard_Boolean Shape::is_null() const { return shape.IsNull(); }
+
 // Edge
 
 Edge Edge::from_curve(const occara::geom::TrimmedCurve &curve) {

--- a/crates/occara/include/geom.hpp
+++ b/crates/occara/include/geom.hpp
@@ -70,6 +70,9 @@ struct Direction {
 
   static Direction create(Standard_Real x, Standard_Real y, Standard_Real z);
   Direction clone() const;
+
+  void get_components(Standard_Real &x, Standard_Real &y,
+                      Standard_Real &z) const;
 };
 
 struct Direction2D {
@@ -77,6 +80,8 @@ struct Direction2D {
 
   static Direction2D create(Standard_Real x, Standard_Real y);
   Direction2D clone() const;
+
+  void get_components(Standard_Real &x, Standard_Real &y) const;
 };
 
 struct Axis {
@@ -84,6 +89,9 @@ struct Axis {
 
   static Axis create(const Point &origin, const Direction &direction);
   Axis clone() const;
+
+  Point location() const;
+  Direction direction() const;
 };
 
 struct Axis2D {
@@ -91,6 +99,9 @@ struct Axis2D {
 
   static Axis2D create(const Point2D &origin, const Direction2D &direction);
   Axis2D clone() const;
+
+  Point2D location() const;
+  Direction2D direction() const;
 };
 
 struct PlaneAxis {
@@ -98,6 +109,9 @@ struct PlaneAxis {
 
   static PlaneAxis create(const Point &origin, const Direction &direction);
   PlaneAxis clone() const;
+
+  Point location() const;
+  Direction direction() const;
 };
 
 struct SpaceAxis {
@@ -105,6 +119,9 @@ struct SpaceAxis {
 
   static SpaceAxis create(const Point &origin, const Direction &direction);
   SpaceAxis clone() const;
+
+  Point location() const;
+  Direction direction() const;
 };
 
 struct TrimmedCurve {

--- a/crates/occara/include/shape.hpp
+++ b/crates/occara/include/shape.hpp
@@ -89,6 +89,8 @@ struct Shape {
 
   FilletBuilder fillet() const;
   Shape fuse(const Shape &other) const;
+  Shape subtract(const Shape &other) const;
+  Shape intersect(const Shape &other) const;
   static Shape cylinder(const occara::geom::PlaneAxis &axis,
                         Standard_Real radius, Standard_Real height);
   Mesh mesh() const;

--- a/crates/occara/include/shape.hpp
+++ b/crates/occara/include/shape.hpp
@@ -93,6 +93,7 @@ struct Shape {
                         Standard_Real radius, Standard_Real height);
   Mesh mesh() const;
   ShapeType shape_type() const;
+  Standard_Boolean is_null() const;
 };
 
 struct Edge {

--- a/crates/occara/include/shape.hpp
+++ b/crates/occara/include/shape.hpp
@@ -95,6 +95,7 @@ struct Shape {
   ShapeType shape_type() const;
   Standard_Boolean is_null() const;
   Standard_Boolean is_closed() const;
+  Standard_Real mass() const;
 };
 
 struct Edge {

--- a/crates/occara/include/shape.hpp
+++ b/crates/occara/include/shape.hpp
@@ -94,6 +94,7 @@ struct Shape {
   Mesh mesh() const;
   ShapeType shape_type() const;
   Standard_Boolean is_null() const;
+  Standard_Boolean is_closed() const;
 };
 
 struct Edge {

--- a/crates/occara/include/shape.hpp
+++ b/crates/occara/include/shape.hpp
@@ -69,6 +69,19 @@ struct ShellBuilder {
   Shape build();
 };
 
+// This is equal to TopAbs_ShapeEnum
+enum class ShapeType {
+  Compound,
+  CompoundSolid,
+  Solid,
+  Shell,
+  Face,
+  Wire,
+  Edge,
+  Vertex,
+  Shape
+};
+
 struct Shape {
   TopoDS_Shape shape;
 
@@ -79,6 +92,7 @@ struct Shape {
   static Shape cylinder(const occara::geom::PlaneAxis &axis,
                         Standard_Real radius, Standard_Real height);
   Mesh mesh() const;
+  ShapeType shape_type() const;
 };
 
 struct Edge {

--- a/crates/occara/src/geom.rs
+++ b/crates/occara/src/geom.rs
@@ -85,6 +85,15 @@ impl Direction {
     pub fn z() -> Self {
         Self::new(0.0, 0.0, 1.0)
     }
+    // TODO: maybe rename x/y/z to new_x/new_y/new_z and add x() -> f64
+
+    #[must_use]
+    pub fn get_components(&self) -> (f64, f64, f64) {
+        let (mut x, mut y, mut z) = (0.0, 0.0, 0.0);
+        self.0
+            .get_components(Pin::new(&mut x), Pin::new(&mut y), Pin::new(&mut z));
+        (x, y, z)
+    }
 }
 
 impl Clone for Direction {
@@ -107,6 +116,16 @@ impl Axis {
     #[must_use]
     pub fn new(location: &Point, direction: &Direction) -> Self {
         Self(ffi_geom::Axis::create(&location.0, &direction.0).within_box())
+    }
+
+    #[must_use]
+    pub fn location(&self) -> Point {
+        Point(self.0.location().within_box())
+    }
+
+    #[must_use]
+    pub fn direction(&self) -> Direction {
+        Direction(self.0.direction().within_box())
     }
 }
 
@@ -191,6 +210,13 @@ impl Direction2D {
     pub fn y() -> Self {
         Self::new(0.0, 1.0)
     }
+
+    #[must_use]
+    pub fn get_components(&self) -> (f64, f64) {
+        let (mut x, mut y) = (0.0, 0.0);
+        self.0.get_components(Pin::new(&mut x), Pin::new(&mut y));
+        (x, y)
+    }
 }
 
 impl Clone for Direction2D {
@@ -213,6 +239,16 @@ impl Axis2D {
     #[must_use]
     pub fn new(location: &Point2D, direction: &Direction2D) -> Self {
         Self(ffi_geom::Axis2D::create(&location.0, &direction.0).within_box())
+    }
+
+    #[must_use]
+    pub fn location(&self) -> Point2D {
+        Point2D(self.0.location().within_box())
+    }
+
+    #[must_use]
+    pub fn direction(&self) -> Direction2D {
+        Direction2D(self.0.direction().within_box())
     }
 }
 
@@ -237,6 +273,16 @@ impl PlaneAxis {
     pub fn new(location: &Point, direction: &Direction) -> Self {
         Self(ffi_geom::PlaneAxis::create(&location.0, &direction.0).within_box())
     }
+
+    #[must_use]
+    pub fn location(&self) -> Point {
+        Point(self.0.location().within_box())
+    }
+
+    #[must_use]
+    pub fn direction(&self) -> Direction {
+        Direction(self.0.direction().within_box())
+    }
 }
 
 impl Clone for PlaneAxis {
@@ -259,6 +305,16 @@ impl SpaceAxis {
     #[must_use]
     pub fn new(location: &Point, direction: &Direction) -> Self {
         Self(ffi_geom::SpaceAxis::create(&location.0, &direction.0).within_box())
+    }
+
+    #[must_use]
+    pub fn location(&self) -> Point {
+        Point(self.0.location().within_box())
+    }
+
+    #[must_use]
+    pub fn direction(&self) -> Direction {
+        Direction(self.0.direction().within_box())
     }
 }
 

--- a/crates/occara/src/geom.rs
+++ b/crates/occara/src/geom.rs
@@ -55,6 +55,14 @@ impl Clone for Point {
     }
 }
 
+// SAFETY: Safe because the underlying C++ type contains no thread-local state
+// and all internal data is properly encapsulated.
+unsafe impl Send for Point {}
+
+// SAFETY: Safe because this type provides no shared mutable access, and the underlying
+// C++ type is designed for thread-safe read operations.
+unsafe impl Sync for Point {}
+
 pub struct Direction(pub(crate) Pin<Box<ffi_geom::Direction>>);
 
 impl Direction {
@@ -85,6 +93,14 @@ impl Clone for Direction {
     }
 }
 
+// SAFETY: Safe because the underlying C++ type contains no thread-local state
+// and all internal data is properly encapsulated.
+unsafe impl Send for Direction {}
+
+// SAFETY: Safe because this type provides no shared mutable access, and the underlying
+// C++ type is designed for thread-safe read operations.
+unsafe impl Sync for Direction {}
+
 pub struct Axis(pub(crate) Pin<Box<ffi_geom::Axis>>);
 
 impl Axis {
@@ -99,6 +115,14 @@ impl Clone for Axis {
         Self(self.0.clone().within_box())
     }
 }
+
+// SAFETY: Safe because the underlying C++ type contains no thread-local state
+// and all internal data is properly encapsulated.
+unsafe impl Send for Axis {}
+
+// SAFETY: Safe because this type provides no shared mutable access, and the underlying
+// C++ type is designed for thread-safe read operations.
+unsafe impl Sync for Axis {}
 
 pub struct Point2D(pub(crate) Pin<Box<ffi_geom::Point2D>>);
 
@@ -142,6 +166,14 @@ impl Clone for Point2D {
     }
 }
 
+// SAFETY: Safe because the underlying C++ type contains no thread-local state
+// and all internal data is properly encapsulated.
+unsafe impl Send for Point2D {}
+
+// SAFETY: Safe because this type provides no shared mutable access, and the underlying
+// C++ type is designed for thread-safe read operations.
+unsafe impl Sync for Point2D {}
+
 pub struct Direction2D(pub(crate) Pin<Box<ffi_geom::Direction2D>>);
 
 impl Direction2D {
@@ -167,6 +199,14 @@ impl Clone for Direction2D {
     }
 }
 
+// SAFETY: Safe because the underlying C++ type contains no thread-local state
+// and all internal data is properly encapsulated.
+unsafe impl Send for Direction2D {}
+
+// SAFETY: Safe because this type provides no shared mutable access, and the underlying
+// C++ type is designed for thread-safe read operations.
+unsafe impl Sync for Direction2D {}
+
 pub struct Axis2D(pub(crate) Pin<Box<ffi_geom::Axis2D>>);
 
 impl Axis2D {
@@ -181,6 +221,14 @@ impl Clone for Axis2D {
         Self(self.0.clone().within_box())
     }
 }
+
+// SAFETY: Safe because the underlying C++ type contains no thread-local state
+// and all internal data is properly encapsulated.
+unsafe impl Send for Axis2D {}
+
+// SAFETY: Safe because this type provides no shared mutable access, and the underlying
+// C++ type is designed for thread-safe read operations.
+unsafe impl Sync for Axis2D {}
 
 pub struct PlaneAxis(pub(crate) Pin<Box<ffi_geom::PlaneAxis>>);
 
@@ -197,6 +245,14 @@ impl Clone for PlaneAxis {
     }
 }
 
+// SAFETY: Safe because the underlying C++ type contains no thread-local state
+// and all internal data is properly encapsulated.
+unsafe impl Send for PlaneAxis {}
+
+// SAFETY: Safe because this type provides no shared mutable access, and the underlying
+// C++ type is designed for thread-safe read operations.
+unsafe impl Sync for PlaneAxis {}
+
 pub struct SpaceAxis(pub(crate) Pin<Box<ffi_geom::SpaceAxis>>);
 
 impl SpaceAxis {
@@ -211,6 +267,14 @@ impl Clone for SpaceAxis {
         Self(self.0.clone().within_box())
     }
 }
+
+// SAFETY: Safe because the underlying C++ type contains no thread-local state
+// and all internal data is properly encapsulated.
+unsafe impl Send for SpaceAxis {}
+
+// SAFETY: Safe because this type provides no shared mutable access, and the underlying
+// C++ type is designed for thread-safe read operations.
+unsafe impl Sync for SpaceAxis {}
 
 pub struct TrimmedCurve(pub(crate) Pin<Box<ffi_geom::TrimmedCurve>>);
 
@@ -247,6 +311,14 @@ impl Clone for TrimmedCurve2D {
     }
 }
 
+// SAFETY: Safe because the underlying C++ type contains no thread-local state
+// and all internal data is properly encapsulated.
+unsafe impl Send for TrimmedCurve2D {}
+
+// SAFETY: Safe because this type provides no shared mutable access, and the underlying
+// C++ type is designed for thread-safe read operations.
+unsafe impl Sync for TrimmedCurve2D {}
+
 pub struct Curve2D(pub(crate) Pin<Box<ffi_geom::Curve2D>>);
 
 impl Curve2D {
@@ -268,6 +340,14 @@ impl Clone for Curve2D {
         Self(self.0.clone().within_box())
     }
 }
+
+// SAFETY: Safe because the underlying C++ type contains no thread-local state
+// and all internal data is properly encapsulated.
+unsafe impl Send for Curve2D {}
+
+// SAFETY: Safe because this type provides no shared mutable access, and the underlying
+// C++ type is designed for thread-safe read operations.
+unsafe impl Sync for Curve2D {}
 
 pub struct Ellipse2D(pub(crate) Pin<Box<ffi_geom::Ellipse2D>>);
 
@@ -295,6 +375,14 @@ impl Clone for Ellipse2D {
     }
 }
 
+// SAFETY: Safe because the underlying C++ type contains no thread-local state
+// and all internal data is properly encapsulated.
+unsafe impl Send for Ellipse2D {}
+
+// SAFETY: Safe because this type provides no shared mutable access, and the underlying
+// C++ type is designed for thread-safe read operations.
+unsafe impl Sync for Ellipse2D {}
+
 pub struct Plane(pub(crate) Pin<Box<ffi_geom::Plane>>);
 
 impl Plane {
@@ -310,6 +398,14 @@ impl Clone for Plane {
         Self(self.0.clone().within_box())
     }
 }
+
+// SAFETY: Safe because the underlying C++ type contains no thread-local state
+// and all internal data is properly encapsulated.
+unsafe impl Send for Plane {}
+
+// SAFETY: Safe because this type provides no shared mutable access, and the underlying
+// C++ type is designed for thread-safe read operations.
+unsafe impl Sync for Plane {}
 
 pub struct Surface(pub(crate) Pin<Box<ffi_geom::Surface>>);
 
@@ -336,6 +432,14 @@ impl Clone for Surface {
         Self(self.0.clone().within_box())
     }
 }
+
+// SAFETY: Safe because the underlying C++ type contains no thread-local state
+// and all internal data is properly encapsulated.
+unsafe impl Send for Surface {}
+
+// SAFETY: Safe because this type provides no shared mutable access, and the underlying
+// C++ type is designed for thread-safe read operations.
+unsafe impl Sync for Surface {}
 
 pub trait Transformable {
     #[must_use]
@@ -364,6 +468,14 @@ impl Clone for Transformation {
     }
 }
 
+// SAFETY: Safe because the underlying C++ type contains no thread-local state
+// and all internal data is properly encapsulated.
+unsafe impl Send for Transformation {}
+
+// SAFETY: Safe because this type provides no shared mutable access, and the underlying
+// C++ type is designed for thread-safe read operations.
+unsafe impl Sync for Transformation {}
+
 pub struct Vector(pub(crate) Pin<Box<ffi_geom::Vector>>);
 
 impl Vector {
@@ -379,6 +491,14 @@ impl Clone for Vector {
     }
 }
 
+// SAFETY: Safe because the underlying C++ type contains no thread-local state
+// and all internal data is properly encapsulated.
+unsafe impl Send for Vector {}
+
+// SAFETY: Safe because this type provides no shared mutable access, and the underlying
+// C++ type is designed for thread-safe read operations.
+unsafe impl Sync for Vector {}
+
 pub struct CylindricalSurface(pub(crate) Pin<Box<ffi_geom::CylindricalSurface>>);
 
 impl CylindricalSurface {
@@ -393,3 +513,10 @@ impl Clone for CylindricalSurface {
         Self(self.0.clone().within_box())
     }
 }
+// SAFETY: Safe because the underlying C++ type contains no thread-local state
+// and all internal data is properly encapsulated.
+unsafe impl Send for CylindricalSurface {}
+
+// SAFETY: Safe because this type provides no shared mutable access, and the underlying
+// C++ type is designed for thread-safe read operations.
+unsafe impl Sync for CylindricalSurface {}

--- a/crates/occara/src/geom.rs
+++ b/crates/occara/src/geom.rs
@@ -1,6 +1,6 @@
 use crate::ffi::occara::geom as ffi_geom;
 use autocxx::prelude::*;
-use std::pin::Pin;
+use std::{fmt, pin::Pin};
 
 pub struct Point(pub(crate) Pin<Box<ffi_geom::Point>>);
 
@@ -55,6 +55,24 @@ impl Clone for Point {
     }
 }
 
+impl fmt::Display for Point {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let (x, y, z) = self.get_coordinates();
+        write!(f, "Vertex({x:.6}, {y:.6}, {z:.6})")
+    }
+}
+
+impl fmt::Debug for Point {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let (x, y, z) = self.get_coordinates();
+        f.debug_struct("Vertex")
+            .field("x", &x)
+            .field("y", &y)
+            .field("z", &z)
+            .finish()
+    }
+}
+
 // SAFETY: Safe because the underlying C++ type contains no thread-local state
 // and all internal data is properly encapsulated.
 unsafe impl Send for Point {}
@@ -102,6 +120,24 @@ impl Clone for Direction {
     }
 }
 
+impl fmt::Display for Direction {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let (x, y, z) = self.get_components();
+        write!(f, "Vertex({x:.6}, {y:.6}, {z:.6})")
+    }
+}
+
+impl fmt::Debug for Direction {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let (x, y, z) = self.get_components();
+        f.debug_struct("Direction")
+            .field("x", &x)
+            .field("y", &y)
+            .field("z", &z)
+            .finish()
+    }
+}
+
 // SAFETY: Safe because the underlying C++ type contains no thread-local state
 // and all internal data is properly encapsulated.
 unsafe impl Send for Direction {}
@@ -132,6 +168,27 @@ impl Axis {
 impl Clone for Axis {
     fn clone(&self) -> Self {
         Self(self.0.clone().within_box())
+    }
+}
+
+impl fmt::Display for Axis {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let loc = self.location().get_coordinates();
+        let dir = self.direction().get_components();
+        write!(
+            f,
+            "Axis(loc: ({:.2}, {:.2}, {:.2}), dir: ({:.2}, {:.2}, {:.2}))",
+            loc.0, loc.1, loc.2, dir.0, dir.1, dir.2,
+        )
+    }
+}
+
+impl fmt::Debug for Axis {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Axis")
+            .field("location", &self.location())
+            .field("direction", &self.direction())
+            .finish()
     }
 }
 
@@ -185,6 +242,23 @@ impl Clone for Point2D {
     }
 }
 
+impl fmt::Display for Point2D {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let (x, y) = self.get_coordinates();
+        write!(f, "Point2D({x:.6}, {y:.6})")
+    }
+}
+
+impl fmt::Debug for Point2D {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let (x, y) = self.get_coordinates();
+        f.debug_struct("Point2D")
+            .field("x", &x)
+            .field("y", &y)
+            .finish()
+    }
+}
+
 // SAFETY: Safe because the underlying C++ type contains no thread-local state
 // and all internal data is properly encapsulated.
 unsafe impl Send for Point2D {}
@@ -225,6 +299,23 @@ impl Clone for Direction2D {
     }
 }
 
+impl fmt::Display for Direction2D {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let (x, y) = self.get_components();
+        write!(f, "Direction2D({x:.6}, {y:.6})")
+    }
+}
+
+impl fmt::Debug for Direction2D {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let (x, y) = self.get_components();
+        f.debug_struct("Direction2D")
+            .field("x", &x)
+            .field("y", &y)
+            .finish()
+    }
+}
+
 // SAFETY: Safe because the underlying C++ type contains no thread-local state
 // and all internal data is properly encapsulated.
 unsafe impl Send for Direction2D {}
@@ -255,6 +346,27 @@ impl Axis2D {
 impl Clone for Axis2D {
     fn clone(&self) -> Self {
         Self(self.0.clone().within_box())
+    }
+}
+
+impl fmt::Display for Axis2D {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let loc = self.location().get_coordinates();
+        let dir = self.direction().get_components();
+        write!(
+            f,
+            "Axis2D(loc: ({:.2}, {:.2}), dir: ({:.2}, {:.2}))",
+            loc.0, loc.1, dir.0, dir.1,
+        )
+    }
+}
+
+impl fmt::Debug for Axis2D {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Axis2D")
+            .field("location", &self.location())
+            .field("direction", &self.direction())
+            .finish()
     }
 }
 
@@ -291,6 +403,27 @@ impl Clone for PlaneAxis {
     }
 }
 
+impl fmt::Display for PlaneAxis {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let loc = self.location().get_coordinates();
+        let dir = self.direction().get_components();
+        write!(
+            f,
+            "PlaneAxis(loc: ({:.2}, {:.2}, {:.2}), dir: ({:.2}, {:.2}, {:.2}))",
+            loc.0, loc.1, loc.2, dir.0, dir.1, dir.2,
+        )
+    }
+}
+
+impl fmt::Debug for PlaneAxis {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("PlaneAxis")
+            .field("location", &self.location())
+            .field("direction", &self.direction())
+            .finish()
+    }
+}
+
 // SAFETY: Safe because the underlying C++ type contains no thread-local state
 // and all internal data is properly encapsulated.
 unsafe impl Send for PlaneAxis {}
@@ -321,6 +454,27 @@ impl SpaceAxis {
 impl Clone for SpaceAxis {
     fn clone(&self) -> Self {
         Self(self.0.clone().within_box())
+    }
+}
+
+impl fmt::Display for SpaceAxis {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let loc = self.location().get_coordinates();
+        let dir = self.direction().get_components();
+        write!(
+            f,
+            "SpaceAxis(loc: ({:.2}, {:.2}, {:.2}), dir: ({:.2}, {:.2}, {:.2}))",
+            loc.0, loc.1, loc.2, dir.0, dir.1, dir.2,
+        )
+    }
+}
+
+impl fmt::Debug for SpaceAxis {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("SpaceAxis")
+            .field("location", &self.location())
+            .field("direction", &self.direction())
+            .finish()
     }
 }
 
@@ -367,6 +521,13 @@ impl Clone for TrimmedCurve2D {
     }
 }
 
+impl fmt::Debug for TrimmedCurve2D {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // TODO: be more informative
+        f.debug_struct("TrimmedCurve2D").finish()
+    }
+}
+
 // SAFETY: Safe because the underlying C++ type contains no thread-local state
 // and all internal data is properly encapsulated.
 unsafe impl Send for TrimmedCurve2D {}
@@ -394,6 +555,13 @@ impl From<&TrimmedCurve2D> for Curve2D {
 impl Clone for Curve2D {
     fn clone(&self) -> Self {
         Self(self.0.clone().within_box())
+    }
+}
+
+impl fmt::Debug for Curve2D {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // TODO: be more informative
+        f.debug_struct("Curve2D").finish()
     }
 }
 
@@ -431,6 +599,13 @@ impl Clone for Ellipse2D {
     }
 }
 
+impl fmt::Debug for Ellipse2D {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // TODO: be more informative
+        f.debug_struct("Ellipse2D").finish()
+    }
+}
+
 // SAFETY: Safe because the underlying C++ type contains no thread-local state
 // and all internal data is properly encapsulated.
 unsafe impl Send for Ellipse2D {}
@@ -452,6 +627,13 @@ impl Plane {
 impl Clone for Plane {
     fn clone(&self) -> Self {
         Self(self.0.clone().within_box())
+    }
+}
+
+impl fmt::Debug for Plane {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // TODO: be more informative
+        f.debug_struct("Plane").finish()
     }
 }
 
@@ -486,6 +668,13 @@ impl Surface {
 impl Clone for Surface {
     fn clone(&self) -> Self {
         Self(self.0.clone().within_box())
+    }
+}
+
+impl fmt::Debug for Surface {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // TODO: be more informative
+        f.debug_struct("Surface").finish()
     }
 }
 
@@ -524,6 +713,13 @@ impl Clone for Transformation {
     }
 }
 
+impl fmt::Debug for Transformation {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // TODO: be more informative
+        f.debug_struct("Transformation").finish()
+    }
+}
+
 // SAFETY: Safe because the underlying C++ type contains no thread-local state
 // and all internal data is properly encapsulated.
 unsafe impl Send for Transformation {}
@@ -544,6 +740,13 @@ impl Vector {
 impl Clone for Vector {
     fn clone(&self) -> Self {
         Self(self.0.clone().within_box())
+    }
+}
+
+impl fmt::Debug for Vector {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // TODO: be more informative
+        f.debug_struct("Vector").finish()
     }
 }
 
@@ -569,6 +772,14 @@ impl Clone for CylindricalSurface {
         Self(self.0.clone().within_box())
     }
 }
+
+impl fmt::Debug for CylindricalSurface {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // TODO: be more informative
+        f.debug_struct("CylindricalSurface").finish()
+    }
+}
+
 // SAFETY: Safe because the underlying C++ type contains no thread-local state
 // and all internal data is properly encapsulated.
 unsafe impl Send for CylindricalSurface {}

--- a/crates/occara/src/lib.rs
+++ b/crates/occara/src/lib.rs
@@ -2,6 +2,9 @@
 #![warn(clippy::pedantic)]
 #![allow(clippy::module_name_repetitions)]
 #![allow(clippy::cognitive_complexity)]
+// We can not implement Send on the underlying autocxx managed raw pointer, therefore this
+// lint is not applicable here.
+#![allow(clippy::non_send_fields_in_send_ty)]
 
 mod ffi;
 

--- a/crates/occara/src/shape.rs
+++ b/crates/occara/src/shape.rs
@@ -114,6 +114,16 @@ impl Shape {
     }
 
     #[must_use]
+    pub fn subtract(&self, other: &Self) -> Self {
+        Self(self.0.subtract(&other.0).within_box())
+    }
+
+    #[must_use]
+    pub fn intersect(&self, other: &Self) -> Self {
+        Self(self.0.intersect(&other.0).within_box())
+    }
+
+    #[must_use]
     pub fn shell(&self) -> ShellBuilder {
         ShellBuilder(ffi_shape::ShellBuilder::create(&self.0).within_box())
     }

--- a/crates/occara/src/shape.rs
+++ b/crates/occara/src/shape.rs
@@ -44,6 +44,14 @@ impl Clone for Vertex {
     }
 }
 
+// SAFETY: Safe because the underlying C++ type contains no thread-local state
+// and all internal data is properly encapsulated.
+unsafe impl Send for Vertex {}
+
+// SAFETY: Safe because this type provides no shared mutable access, and the underlying
+// C++ type is designed for thread-safe read operations.
+unsafe impl Sync for Vertex {}
+
 pub struct Shape(pub(crate) Pin<Box<ffi_shape::Shape>>);
 
 impl Shape {
@@ -88,6 +96,14 @@ impl Clone for Shape {
         Self(self.0.clone().within_box())
     }
 }
+
+// SAFETY: Safe because the underlying C++ type contains no thread-local state
+// and all internal data is properly encapsulated.
+unsafe impl Send for Shape {}
+
+// SAFETY: Safe because this type provides no shared mutable access, and the underlying
+// C++ type is designed for thread-safe read operations.
+unsafe impl Sync for Shape {}
 
 pub struct Mesh(pub(crate) Pin<Box<ffi_shape::Mesh>>);
 
@@ -149,6 +165,14 @@ impl Mesh {
     }
 }
 
+// SAFETY: Safe because the underlying C++ type contains no thread-local state
+// and all internal data is properly encapsulated.
+unsafe impl Send for Mesh {}
+
+// SAFETY: Safe because this type provides no shared mutable access, and the underlying
+// C++ type is designed for thread-safe read operations.
+unsafe impl Sync for Mesh {}
+
 pub struct EdgeIterator(pub(crate) Pin<Box<ffi_shape::EdgeIterator>>);
 
 impl Iterator for EdgeIterator {
@@ -169,6 +193,14 @@ impl Clone for EdgeIterator {
         Self(self.0.clone().within_box())
     }
 }
+
+// SAFETY: Safe because the underlying C++ type contains no thread-local state
+// and all internal data is properly encapsulated.
+unsafe impl Send for EdgeIterator {}
+
+// SAFETY: Safe because this type provides no shared mutable access, and the underlying
+// C++ type is designed for thread-safe read operations.
+unsafe impl Sync for EdgeIterator {}
 
 pub struct FaceIterator(pub(crate) Pin<Box<ffi_shape::FaceIterator>>);
 
@@ -191,6 +223,14 @@ impl Clone for FaceIterator {
     }
 }
 
+// SAFETY: Safe because the underlying C++ type contains no thread-local state
+// and all internal data is properly encapsulated.
+unsafe impl Send for FaceIterator {}
+
+// SAFETY: Safe because this type provides no shared mutable access, and the underlying
+// C++ type is designed for thread-safe read operations.
+unsafe impl Sync for FaceIterator {}
+
 pub struct FilletBuilder(pub(crate) Pin<Box<ffi_shape::FilletBuilder>>);
 
 impl FilletBuilder {
@@ -208,6 +248,14 @@ impl Clone for FilletBuilder {
         Self(self.0.clone().within_box())
     }
 }
+
+// SAFETY: Safe because the underlying C++ type contains no thread-local state
+// and all internal data is properly encapsulated.
+unsafe impl Send for FilletBuilder {}
+
+// SAFETY: Safe because this type provides no shared mutable access, and the underlying
+// C++ type is designed for thread-safe read operations.
+unsafe impl Sync for FilletBuilder {}
 
 pub struct ShellBuilder(pub(crate) Pin<Box<ffi_shape::ShellBuilder>>);
 
@@ -240,6 +288,14 @@ impl Clone for ShellBuilder {
     }
 }
 
+// SAFETY: Safe because the underlying C++ type contains no thread-local state
+// and all internal data is properly encapsulated.
+unsafe impl Send for ShellBuilder {}
+
+// SAFETY: Safe because this type provides no shared mutable access, and the underlying
+// C++ type is designed for thread-safe read operations.
+unsafe impl Sync for ShellBuilder {}
+
 pub struct Edge(pub(crate) Pin<Box<ffi_shape::Edge>>);
 
 impl Edge {
@@ -271,6 +327,14 @@ impl From<geom::TrimmedCurve> for Edge {
     }
 }
 
+// SAFETY: Safe because the underlying C++ type contains no thread-local state
+// and all internal data is properly encapsulated.
+unsafe impl Send for Edge {}
+
+// SAFETY: Safe because this type provides no shared mutable access, and the underlying
+// C++ type is designed for thread-safe read operations.
+unsafe impl Sync for Edge {}
+
 pub struct Face(pub(crate) Pin<Box<ffi_shape::Face>>);
 
 impl Face {
@@ -290,6 +354,14 @@ impl Clone for Face {
         Self(self.0.clone().within_box())
     }
 }
+
+// SAFETY: Safe because the underlying C++ type contains no thread-local state
+// and all internal data is properly encapsulated.
+unsafe impl Send for Face {}
+
+// SAFETY: Safe because this type provides no shared mutable access, and the underlying
+// C++ type is designed for thread-safe read operations.
+unsafe impl Sync for Face {}
 
 pub struct Wire(pub(crate) Pin<Box<ffi_shape::Wire>>);
 
@@ -322,6 +394,14 @@ impl Clone for Wire {
         Self(self.0.clone().within_box())
     }
 }
+
+// SAFETY: Safe because the underlying C++ type contains no thread-local state
+// and all internal data is properly encapsulated.
+unsafe impl Send for Wire {}
+
+// SAFETY: Safe because this type provides no shared mutable access, and the underlying
+// C++ type is designed for thread-safe read operations.
+unsafe impl Sync for Wire {}
 
 impl geom::Transformable for Wire {
     fn transform(&self, transformation: &geom::Transformation) -> Self {
@@ -378,6 +458,14 @@ impl Clone for Loft {
     }
 }
 
+// SAFETY: Safe because the underlying C++ type contains no thread-local state
+// and all internal data is properly encapsulated.
+unsafe impl Send for Loft {}
+
+// SAFETY: Safe because this type provides no shared mutable access, and the underlying
+// C++ type is designed for thread-safe read operations.
+unsafe impl Sync for Loft {}
+
 pub struct Compound(pub(crate) Pin<Box<ffi_shape::Compound>>);
 
 impl Default for Compound {
@@ -401,3 +489,10 @@ impl Compound {
         Shape(self.0.as_mut().build().within_box())
     }
 }
+// SAFETY: Safe because the underlying C++ type contains no thread-local state
+// and all internal data is properly encapsulated.
+unsafe impl Send for Compound {}
+
+// SAFETY: Safe because this type provides no shared mutable access, and the underlying
+// C++ type is designed for thread-safe read operations.
+unsafe impl Sync for Compound {}

--- a/crates/occara/src/shape.rs
+++ b/crates/occara/src/shape.rs
@@ -1,6 +1,7 @@
 use super::ffi::occara::shape as ffi_shape;
 use crate::geom;
 use autocxx::prelude::*;
+use std::fmt;
 use std::io::Write;
 use std::{fs::File, path::Path, pin::Pin};
 
@@ -41,6 +42,24 @@ impl Vertex {
 impl Clone for Vertex {
     fn clone(&self) -> Self {
         Self(self.0.clone().within_box())
+    }
+}
+
+impl fmt::Display for Vertex {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let (x, y, z) = self.get_coordinates();
+        write!(f, "Vertex({x:.6}, {y:.6}, {z:.6})")
+    }
+}
+
+impl fmt::Debug for Vertex {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let (x, y, z) = self.get_coordinates();
+        f.debug_struct("Vertex")
+            .field("x", &x)
+            .field("y", &y)
+            .field("z", &z)
+            .finish()
     }
 }
 
@@ -136,6 +155,22 @@ impl Clone for Shape {
     }
 }
 
+impl fmt::Display for Shape {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "Shape({})", self.shape_type().to_str())
+    }
+}
+
+impl fmt::Debug for Shape {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Shape")
+            .field("type", &self.shape_type().to_str())
+            .field("is_null", &self.is_null())
+            .field("is_closed", &self.is_closed())
+            .finish()
+    }
+}
+
 // SAFETY: Safe because the underlying C++ type contains no thread-local state
 // and all internal data is properly encapsulated.
 unsafe impl Send for Shape {}
@@ -204,6 +239,15 @@ impl Mesh {
     }
 }
 
+impl fmt::Debug for Mesh {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Mesh")
+            .field("vertices", &self.0.as_ref().vertices_size())
+            .field("indices", &self.0.as_ref().indices_size())
+            .finish()
+    }
+}
+
 // SAFETY: Safe because the underlying C++ type contains no thread-local state
 // and all internal data is properly encapsulated.
 unsafe impl Send for Mesh {}
@@ -230,6 +274,13 @@ impl Iterator for EdgeIterator {
 impl Clone for EdgeIterator {
     fn clone(&self) -> Self {
         Self(self.0.clone().within_box())
+    }
+}
+
+impl fmt::Debug for EdgeIterator {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // TODO: be more informative
+        f.debug_struct("EdgeIterator").finish()
     }
 }
 
@@ -262,6 +313,13 @@ impl Clone for FaceIterator {
     }
 }
 
+impl fmt::Debug for FaceIterator {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // TODO: be more informative
+        f.debug_struct("FaceIterator").finish()
+    }
+}
+
 // SAFETY: Safe because the underlying C++ type contains no thread-local state
 // and all internal data is properly encapsulated.
 unsafe impl Send for FaceIterator {}
@@ -285,6 +343,13 @@ impl FilletBuilder {
 impl Clone for FilletBuilder {
     fn clone(&self) -> Self {
         Self(self.0.clone().within_box())
+    }
+}
+
+impl fmt::Debug for FilletBuilder {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // TODO: be more informative
+        f.debug_struct("FilletBuilder").finish()
     }
 }
 
@@ -327,6 +392,13 @@ impl Clone for ShellBuilder {
     }
 }
 
+impl fmt::Debug for ShellBuilder {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // TODO: be more informative
+        f.debug_struct("ShellBuilder").finish()
+    }
+}
+
 // SAFETY: Safe because the underlying C++ type contains no thread-local state
 // and all internal data is properly encapsulated.
 unsafe impl Send for ShellBuilder {}
@@ -366,6 +438,13 @@ impl From<geom::TrimmedCurve> for Edge {
     }
 }
 
+impl fmt::Debug for Edge {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // TODO: be more informative
+        f.debug_struct("Edge").finish()
+    }
+}
+
 // SAFETY: Safe because the underlying C++ type contains no thread-local state
 // and all internal data is properly encapsulated.
 unsafe impl Send for Edge {}
@@ -391,6 +470,13 @@ impl Face {
 impl Clone for Face {
     fn clone(&self) -> Self {
         Self(self.0.clone().within_box())
+    }
+}
+
+impl fmt::Debug for Face {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // TODO: be more informative
+        f.debug_struct("Face").finish()
     }
 }
 
@@ -431,6 +517,13 @@ impl Wire {
 impl Clone for Wire {
     fn clone(&self) -> Self {
         Self(self.0.clone().within_box())
+    }
+}
+
+impl fmt::Debug for Wire {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // TODO: be more informative
+        f.debug_struct("Wire").finish()
     }
 }
 
@@ -497,6 +590,13 @@ impl Clone for Loft {
     }
 }
 
+impl fmt::Debug for Loft {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // TODO: be more informative
+        f.debug_struct("Loft").finish()
+    }
+}
+
 // SAFETY: Safe because the underlying C++ type contains no thread-local state
 // and all internal data is properly encapsulated.
 unsafe impl Send for Loft {}
@@ -528,6 +628,14 @@ impl Compound {
         Shape(self.0.as_mut().build().within_box())
     }
 }
+
+impl fmt::Debug for Compound {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // TODO: be more informative
+        f.debug_struct("Loft").finish()
+    }
+}
+
 // SAFETY: Safe because the underlying C++ type contains no thread-local state
 // and all internal data is properly encapsulated.
 unsafe impl Send for Compound {}

--- a/crates/occara/src/shape.rs
+++ b/crates/occara/src/shape.rs
@@ -123,6 +123,11 @@ impl Shape {
     pub fn is_closed(&self) -> bool {
         ffi_shape::Shape::is_closed(&self.0)
     }
+
+    #[must_use]
+    pub fn mass(&self) -> f64 {
+        ffi_shape::Shape::mass(&self.0)
+    }
 }
 
 impl Clone for Shape {

--- a/crates/occara/src/shape.rs
+++ b/crates/occara/src/shape.rs
@@ -113,6 +113,11 @@ impl Shape {
     pub fn shape_type(&self) -> ShapeType {
         ffi_shape::Shape::shape_type(&self.0)
     }
+
+    #[must_use]
+    pub fn is_null(&self) -> bool {
+        ffi_shape::Shape::is_null(&self.0)
+    }
 }
 
 impl Clone for Shape {

--- a/crates/occara/src/shape.rs
+++ b/crates/occara/src/shape.rs
@@ -118,6 +118,11 @@ impl Shape {
     pub fn is_null(&self) -> bool {
         ffi_shape::Shape::is_null(&self.0)
     }
+
+    #[must_use]
+    pub fn is_closed(&self) -> bool {
+        ffi_shape::Shape::is_closed(&self.0)
+    }
 }
 
 impl Clone for Shape {

--- a/crates/occara/src/shape.rs
+++ b/crates/occara/src/shape.rs
@@ -54,6 +54,25 @@ unsafe impl Sync for Vertex {}
 
 pub struct Shape(pub(crate) Pin<Box<ffi_shape::Shape>>);
 
+pub use crate::shape::ffi_shape::ShapeType;
+
+impl ShapeType {
+    #[must_use]
+    pub const fn to_str(&self) -> &'static str {
+        match self {
+            Self::Compound => "Compound",
+            Self::CompoundSolid => "CompoundSolid",
+            Self::Solid => "Solid",
+            Self::Shell => "Shell",
+            Self::Face => "Face",
+            Self::Wire => "Wire",
+            Self::Edge => "Edge",
+            Self::Vertex => "Vertex",
+            Self::Shape => "Shape",
+        }
+    }
+}
+
 impl Shape {
     #[must_use]
     pub fn fillet(&self) -> FilletBuilder {
@@ -88,6 +107,11 @@ impl Shape {
     #[must_use]
     pub fn mesh(&self) -> Mesh {
         Mesh(ffi_shape::Shape::mesh(&self.0).within_box())
+    }
+
+    #[must_use]
+    pub fn shape_type(&self) -> ShapeType {
+        ffi_shape::Shape::shape_type(&self.0)
     }
 }
 

--- a/crates/occara/tests/thread_safety.rs
+++ b/crates/occara/tests/thread_safety.rs
@@ -1,0 +1,37 @@
+use std::{sync::Arc, thread};
+
+use occara::{
+    geom::{Direction, Point},
+    shape::Shape,
+};
+
+#[test]
+fn test_thread_safety() {
+    // This is a basic test for verifying that this library is probably thread safe.
+    // Since all wrapper types function roughly in the same way, we will only test `Mesh` here.
+    // This test passes while using valgrind.
+    // It may still be possible that (form a type system) independent objects cause a race condition.
+    let plane = Point::new(0.0, 0.0, 0.0).plane_axis_with(&Direction::z());
+    let mesh = Shape::cylinder(&plane, 1.0, 1.0).mesh();
+
+    let mesh = Arc::new(mesh);
+    let handles: Vec<_> = (0..200)
+        .map(|_| {
+            let m = mesh.clone();
+            thread::spawn(move || {
+                let _ = m.vertices();
+                let _ = m.indices();
+            })
+        })
+        .collect();
+    for h in handles {
+        h.join().unwrap();
+    }
+
+    thread::spawn(|| {
+        // This tests the Send trait
+        std::mem::drop(mesh);
+    })
+    .join()
+    .unwrap();
+}


### PR DESCRIPTION
This PR implements various improvements to `occara`, as required for #32.
This mainly includes:
- Implementing the `Send` and `Sync` traits for all types
- Adding `Debug` and where possible `Display` implementations
- Adding `Shape::subtract()` and `Shape::intersect()`
- Removing leftover debug prints