### PR TITLE
ci: enable dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "build"
+    groups:
+      cargo-dependencies:
+        patterns:
+          - "*"


### PR DESCRIPTION
Enable dependabot on this repository. This configuration will create a single PR per week, with all cargo dependency updates grouped together.