### PR TITLE
refactor(modeling-workspace): split RenderNode to allow future caching

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2574,6 +2574,7 @@ dependencies = [
  "modeling-module",
  "occara",
  "project",
+ "uuid",
  "viewport",
  "workspace",
 ]

--- a/crates/modeling-workspace/Cargo.toml
+++ b/crates/modeling-workspace/Cargo.toml
@@ -21,3 +21,4 @@ project.workspace = true
 iced.workspace = true
 bytemuck.workspace = true
 glam.workspace = true
+uuid.workspace = true

--- a/crates/modeling-workspace/src/viewport.rs
+++ b/crates/modeling-workspace/src/viewport.rs
@@ -20,14 +20,28 @@ fn run(
     _project: &project::ProjectSession,
 ) -> (viewport::SceneGraph, ModelingViewportPluginOutput) {
     let mut graph = ComputeGraph::new();
-    let render_node = graph
+    let model_node = graph
         .add_node(
-            scene_nodes::RenderNode {
+            scene_nodes::ModelNode {
                 data_uuid: self.data_uuid,
             },
-            "render".to_string(),
+            "model".to_string(),
         )
         .unwrap();
+    let meshing_node = graph
+        .add_node(scene_nodes::MeshingNode {}, "meshing".to_string())
+        .unwrap();
+    let render_node = graph
+        .add_node(scene_nodes::RenderNode {}, "render".to_string())
+        .unwrap();
+
+    graph
+        .connect(model_node.output(), meshing_node.input_shape())
+        .expect("just created the nodes");
+    graph
+        .connect(meshing_node.output(), render_node.input_mesh())
+        .expect("just created the nodes");
+
     let update_node = graph
         .add_node(
             scene_nodes::UpdateStateNode {

--- a/crates/modeling-workspace/src/viewport/rendering.rs
+++ b/crates/modeling-workspace/src/viewport/rendering.rs
@@ -11,7 +11,7 @@ use super::{
 #[derive(Debug)]
 pub struct RenderPrimitive {
     pub state: ViewportState,
-    pub mesh: occara::shape::Mesh,
+    pub mesh: MeshData,
 }
 
 #[derive(Copy, Clone, Debug, bytemuck::Pod, bytemuck::Zeroable)]
@@ -34,7 +34,7 @@ impl Vertex {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct MeshData {
     pub vertices: Vec<Vertex>,
     pub indices: Vec<u32>,
@@ -59,16 +59,6 @@ impl shader::Primitive for RenderPrimitive {
             ));
         }
         let pipeline = storage.get_mut::<RenderPipeline>().unwrap();
-        let vertices = self
-            .mesh
-            .vertices()
-            .iter()
-            .map(|p| Vertex {
-                pos: glam::Vec3::new(p.x() as f32, p.y() as f32, p.z() as f32),
-            })
-            .collect();
-        let indices = self.mesh.indices().iter().map(|i| *i as u32).collect();
-        let mesh_data = MeshData { vertices, indices };
         pipeline.update(
             device,
             queue,
@@ -76,7 +66,7 @@ impl shader::Primitive for RenderPrimitive {
             viewport.physical_size(),
             viewport.scale_factor() as f32,
             self,
-            &mesh_data,
+            &self.mesh,
         );
     }
 

--- a/crates/modeling-workspace/src/viewport/scene_nodes.rs
+++ b/crates/modeling-workspace/src/viewport/scene_nodes.rs
@@ -35,7 +35,11 @@ fn run(&self, shape: &occara::shape::Shape) -> MeshData {
         .collect();
     let indices = mesh.indices().iter().map(|i| *i as u32).collect();
 
-    MeshData { vertices, indices }
+    MeshData {
+        vertices,
+        indices,
+        id: uuid::Uuid::new_v4(),
+    }
 }
 
 #[derive(Clone, Debug)]

--- a/crates/modeling-workspace/src/viewport/scene_nodes.rs
+++ b/crates/modeling-workspace/src/viewport/scene_nodes.rs
@@ -2,26 +2,51 @@ use computegraph::node;
 use iced::widget::shader;
 use viewport::ViewportEvent;
 
-use super::{rendering::RenderPrimitive, state::ViewportState};
+use super::{
+    rendering::{MeshData, RenderPrimitive, Vertex},
+    state::ViewportState,
+};
 
 #[derive(Clone, Debug)]
-pub struct RenderNode {
+pub struct ModelNode {
     pub data_uuid: project::data::DataUuid,
 }
 
-#[node(RenderNode)]
-fn run(
-    &self,
-    state: &ViewportState,
-    project: &project::ProjectSession,
-) -> Box<dyn shader::Primitive> {
+#[node(ModelNode)]
+fn run(&self, project: &project::ProjectSession) -> occara::shape::Shape {
     let data_session: project::data::DataSession<modeling_module::ModelingModule> =
         project.open_data(self.data_uuid).unwrap();
-    let shape = data_session.snapshot().persistent.shape();
+
+    data_session.snapshot().persistent.shape()
+}
+
+#[derive(Clone, Debug)]
+pub struct MeshingNode {}
+
+#[node(MeshingNode)]
+fn run(&self, shape: &occara::shape::Shape) -> MeshData {
     let mesh = shape.mesh();
+    let vertices = mesh
+        .vertices()
+        .iter()
+        .map(|p| Vertex {
+            pos: glam::Vec3::new(p.x() as f32, p.y() as f32, p.z() as f32),
+        })
+        .collect();
+    let indices = mesh.indices().iter().map(|i| *i as u32).collect();
+
+    MeshData { vertices, indices }
+}
+
+#[derive(Clone, Debug)]
+pub struct RenderNode {}
+
+#[node(RenderNode)]
+fn run(&self, state: &ViewportState, mesh: &MeshData) -> Box<dyn shader::Primitive> {
+    // TODO: remove cloning to reduce overhead once computegraph allows that
     Box::new(RenderPrimitive {
         state: (*state).clone(),
-        mesh,
+        mesh: (*mesh).clone(),
     })
 }
 


### PR DESCRIPTION
This PR splits `RenderNode` into `ModelNode`, `MeshingNode` and `RenderNode` and makes `MeshData` cache friendly by adding a `id` field, that is randomly generated on construction.

Both changes allow the viewport to reduce redundant computations once `computegraph` supports caching.