### PR TITLE
chore: add devcontainer and VSCode configurations

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,22 @@
+{
+  "name": "Rust WASM Development",
+  "image": "rust:latest",
+  "features": {
+    "ghcr.io/devcontainers/features/node:1": {},
+    "ghcr.io/devcontainers/features/rust:1": {},
+    "ghcr.io/devcontainers-community/features/llvm:3": {}
+  },
+  "postCreateCommand": "bash .devcontainer/setup.sh",
+  "forwardPorts": [
+    8080
+  ],
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "rust-lang.rust-analyzer",
+        "tamasfe.even-better-toml",
+        "ms-vscode.wasm-dwarf-debugging"
+      ]
+    }
+  }
+}

--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -e
+apt update
+apt install -y cmake ninja-build
+rustup install nightly # Required for wasm/c interop
+rustup +nightly target add wasm32-unknown-unknown
+
+curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash
+cargo binstall -y wasm-bindgen-cli wasm-pack cargo-make cargo-nextest simple-http-server
+
+cargo make setup-wasm

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,8 @@
+{
+    "recommendations": [
+        "rust-lang.rust-analyzer",
+        "tamasfe.even-better-toml",
+        "vadimcn.vscode-lldb",
+        "jscearcy.rust-doc-viewer"
+    ]
+}

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,37 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "type": "chrome",
+      "name": "Debug WASM in Chrome",
+      "request": "launch",
+      "url": "http://localhost:8080/",
+      "webRoot": "${workspaceFolder}/crates/cadara",
+      "preLaunchTask": "Serve cadara for WASM (with debug info)",
+      "enableDWARF": true,
+      "sourceMaps": true,
+      "presentation": {
+        "hidden": false,
+        "group": "wasm",
+        "order": 1
+      }
+    },
+    {
+      "type": "lldb",
+      "request": "launch",
+      "name": "Debug cadara",
+      "cargo": {
+        "args": [
+          "build",
+          "--manifest-path",
+          "${workspaceFolder}/crates/cadara/Cargo.toml"
+        ]
+      },
+      "presentation": {
+        "hidden": false,
+        "group": "native",
+        "order": 0
+      }
+    }
+  ],
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,178 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "Build all",
+      "command": "cargo",
+      "args": [
+        "build",
+        "--workspace"
+      ],
+      "problemMatcher": [
+        "$rustc"
+      ],
+      "group": {
+        "kind": "build",
+        "isDefault": true
+      }
+    },
+    {
+      "label": "Test all",
+      "command": "cargo",
+      "args": [
+        "test",
+        "--workspace"
+      ],
+      "problemMatcher": [
+        "$rustc"
+      ],
+      "group": {
+        "kind": "test",
+        "isDefault": true
+      }
+    },
+    {
+      "label": "Verify all",
+      "command": "cargo",
+      "args": [
+        "make",
+        "verify"
+      ],
+      "problemMatcher": [
+        "$rustc"
+      ],
+      "group": {
+        "kind": "test",
+        "isDefault": false
+      }
+    },
+    {
+      "label": "Verify all (strict)",
+      "command": "cargo",
+      "args": [
+        "make",
+        "verify-strict"
+      ],
+      "problemMatcher": [
+        "$rustc"
+      ],
+      "group": {
+        "kind": "test",
+        "isDefault": false
+      }
+    },
+    {
+      "label": "Run cadara (dev)",
+      "command": "cargo",
+      "args": [
+        "run"
+      ],
+      "options": {
+        "cwd": "${workspaceFolder}/crates/cadara"
+      },
+      "problemMatcher": [
+        "$rustc"
+      ]
+    },
+    {
+      "label": "Run cadara (release)",
+      "command": "cargo",
+      "args": [
+        "run",
+        "--release"
+      ],
+      "options": {
+        "cwd": "${workspaceFolder}/crates/cadara"
+      },
+      "problemMatcher": [
+        "$rustc"
+      ]
+    },
+    {
+      "label": "Build cadara for WASM (dev)",
+      "command": "cargo",
+      "args": [
+        "make",
+        "build-wasm-dev"
+      ],
+      "problemMatcher": [
+        "$rustc"
+      ],
+      "group": "build"
+    },
+    {
+      "label": "Build cadara for WASM (with debug info)",
+      "command": "cargo",
+      "args": [
+        "make",
+        "build-wasm-debug"
+      ],
+      "problemMatcher": [
+        "$rustc"
+      ],
+      "group": "build"
+    },
+    {
+      "label": "Build cadara for WASM (release)",
+      "command": "cargo",
+      "args": [
+        "make",
+        "build-wasm-release"
+      ],
+      "problemMatcher": [
+        "$rustc"
+      ],
+      "group": "build"
+    },
+    {
+      "label": "Serve cadara",
+      "command": "cargo",
+      "args": [
+        "make",
+        "serve"
+      ],
+      "isBackground": true,
+      "problemMatcher": {
+        "pattern": {
+          "regexp": "^$"
+        },
+        "background": {
+          "activeOnStart": true,
+          "beginsPattern": "\\[cargo-make\\] INFO - Execute Command: \"simple-http-server\"",
+          "endsPattern": "^\\s*Address:"
+        }
+      },
+      "runOptions": {
+        "instanceLimit": 1
+      },
+      "hide": true
+    },
+    {
+      "label": "Serve cadara for WASM (dev)",
+      "dependsOrder": "sequence",
+      "dependsOn": [
+        "Build cadara for WASM (dev)",
+        "Serve cadara"
+      ],
+      "problemMatcher": []
+    },
+    {
+      "label": "Serve cadara for WASM (with debug info)",
+      "dependsOrder": "sequence",
+      "dependsOn": [
+        "Build cadara for WASM (with debug info)",
+        "Serve cadara"
+      ],
+      "problemMatcher": []
+    },
+    {
+      "label": "Serve cadara for WASM (release)",
+      "dependsOrder": "sequence",
+      "dependsOn": [
+        "Build cadara for WASM (release)",
+        "Serve cadara"
+      ],
+      "problemMatcher": []
+    },
+  ]
+}


### PR DESCRIPTION
This PR adds development environment configurations:

- Add devcontainer configuration including WASM32 build support
- Add VSCode tasks and launch configurations for:
  - Native builds and debugging
  - WASM builds and debugging
  - Running tests using `cargo make verify` and `cargo make verify-strict`

The configurations make it easier to get started with development by providing a consistent and pre-configured environment.