### PR TITLE
feat(occara): add tests for wasm32

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2566,6 +2566,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "minicov"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f27fe9f1cc3c22e1687f9446c2083c4c5fc7f0bcf1c7a86bdbded14985895b4b"
+dependencies = [
+ "cc",
+ "walkdir",
+]
+
+[[package]]
 name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3072,6 +3082,8 @@ dependencies = [
  "miette",
  "opencascade-sys",
  "walkdir",
+ "wasm-bindgen-test",
+ "wasm-libc",
 ]
 
 [[package]]
@@ -4658,9 +4670,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.42"
+version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76bc14366121efc8dbb487ab05bcc9d346b3b5ec0eaa76e46594cabbe51762c0"
+checksum = "cc7ec4f8827a71586374db3e87abdb5a2bb3a15afed140221307c3ec06b1f63b"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -4696,6 +4708,32 @@ name = "wasm-bindgen-shared"
 version = "0.2.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "65fc09f10666a9f147042251e0dda9c18f166ff7de300607007e96bdebc1068d"
+
+[[package]]
+name = "wasm-bindgen-test"
+version = "0.3.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d381749acb0943d357dcbd8f0b100640679883fcdeeef04def49daf8d33a5426"
+dependencies = [
+ "console_error_panic_hook",
+ "js-sys",
+ "minicov",
+ "scoped-tls",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-bindgen-test-macro",
+]
+
+[[package]]
+name = "wasm-bindgen-test-macro"
+version = "0.3.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c97b2ef2c8d627381e51c071c2ab328eac606d3f69dd82bcbca20a9e389d95f0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.79",
+]
 
 [[package]]
 name = "wasm-libc"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,6 +58,7 @@ console_error_panic_hook = "0.1"
 console_log = "1.0"
 log = "0.4"
 wasm-bindgen = "0.2"
+wasm-bindgen-test = "0.3"
 
 [workspace.package]
 version = "0.1.0"

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -231,6 +231,8 @@ script_runner = "@shell"
 script = '''
 WASM32_UNKNOWN_UNKNOWN_STDLIB_DIR="$(pwd)/target/wasm-libcxx/wasm32-unknown-unknown-libcxx" # shell2batch:
 . $WASM32_UNKNOWN_UNKNOWN_STDLIB_DIR/env.sh # shell2batch: call target\wasm-libcxx\wasm32-unknown-unknown-libcxx\env.bat
+cd crates/occara
+rustup run nightly wasm-pack test --node
 '''
 install_crate = "wasm-pack"
 

--- a/crates/occara/Cargo.toml
+++ b/crates/occara/Cargo.toml
@@ -23,8 +23,12 @@ walkdir.workspace = true
 autocxx-build.workspace = true
 miette.workspace = true
 
-[dev-dependencies]
+[target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
 criterion.workspace = true
+
+[dev-dependencies]
+wasm-bindgen-test.workspace = true
+wasm-libc.workspace = true
 
 [[bench]]
 name = "occara"

--- a/crates/occara/tests/make_bottle.rs
+++ b/crates/occara/tests/make_bottle.rs
@@ -1,6 +1,7 @@
 use occara::internal::{make_bottle_cpp, make_bottle_rust};
 use std::sync::Arc;
 use std::thread;
+use wasm_bindgen_test::*;
 
 #[test]
 #[ignore] // Don't run this test by default, since its quite slow
@@ -26,4 +27,24 @@ fn test_make_bottle() {
 
     assert!(error_rust_cpp.join().unwrap() < EPSILON);
     assert!(error_cpp_rust.join().unwrap() < EPSILON);
+}
+
+#[wasm_bindgen_test]
+#[allow(dead_code)]
+fn test_make_bottle_wasm() {
+    // TODO(wasm32): This test fails, since exceptions are broken
+    wasm_libc::init();
+    const WIDTH: f64 = 50.0;
+    const HEIGHT: f64 = 70.0;
+    const THICKNESS: f64 = 30.0;
+    const EPSILON: f64 = 1e-6;
+
+    let bottle_rust = make_bottle_rust(WIDTH, HEIGHT, THICKNESS);
+    let bottle_cpp = make_bottle_cpp(WIDTH, HEIGHT, THICKNESS);
+
+    let error_rust_cpp = bottle_rust.subtract(&bottle_cpp).mass();
+    let error_cpp_rust = bottle_cpp.subtract(&bottle_rust).mass();
+
+    assert!(error_rust_cpp < EPSILON);
+    assert!(error_cpp_rust < EPSILON);
 }

--- a/crates/occara/tests/meshing.rs
+++ b/crates/occara/tests/meshing.rs
@@ -2,9 +2,11 @@ use occara::{
     geom::{Direction, Point},
     shape::Shape,
 };
+use wasm_bindgen_test::*;
 
-#[test]
+#[wasm_bindgen_test(unsupported = test)]
 fn test_mesh_cylinder() {
+    wasm_libc::init();
     let plane = Point::new(0.0, 0.0, 0.0).plane_axis_with(&Direction::z());
     let mesh = Shape::cylinder(&plane, 1.0, 1.0).mesh();
     let vertices = mesh.vertices();


### PR DESCRIPTION
This add testing of occara on wasm32.
The `test_make_bottle_wasm` test still fails for now, since constructing C++ exceptions is still broken.

After this is fixed in a future PR, we should run this on CI.