### PR TITLE
refactor(computegraph): remove `compute_with_context` and `compute_untyped_with_context`

### DIFF
--- a/crates/computegraph/src/lib.rs
+++ b/crates/computegraph/src/lib.rs
@@ -1640,45 +1640,6 @@ impl ComputeGraph {
         }
     }
 
-    /// Computes the result for a given output port using the provided context, returning a boxed value.
-    ///
-    /// This function is the untyped version of [`ComputeGraph::compute_with_context`].
-    ///
-    /// This function behaves similarly to [`ComputeGraph::compute_untyped`], but uses
-    /// the values given in the context as described in [`ComputationContext`].
-    ///
-    /// # Arguments
-    ///
-    /// * `output` - The output port to compute.
-    /// * `context` - Collection of values used to perform the computation.
-    ///
-    /// # Returns
-    ///
-    /// A result containing the computed boxed value or an error.
-    ///
-    /// # Errors
-    ///
-    /// An error is returned if:
-    /// - The node is not found.
-    /// - The node has the incorrect output type
-    /// - An input port of the node or a dependency of the node are not connected, and
-    ///   no value is provided via the context
-    /// - A cycle is detected in the graph.
-    #[deprecated]
-    pub fn compute_untyped_with_context(
-        &self,
-        output: OutputPortUntyped,
-        context: &ComputationContext,
-    ) -> Result<Box<dyn SendSyncAny>, ComputeError> {
-        self.compute_untyped_with(
-            output,
-            &ComputationOptions {
-                context: Some(context),
-            },
-            None,
-        )
-    }
-
     /// Computes the result for a given output port.
     ///
     /// Use [`ComputeGraph::compute_with`] when caching or a context are needed.
@@ -1700,50 +1661,6 @@ impl ComputeGraph {
     /// - A cycle is detected in the graph.
     pub fn compute<T: 'static>(&self, output: OutputPort<T>) -> Result<T, ComputeError> {
         let res = self.compute_untyped(output.port.clone())?;
-        let res = res
-            .into_any()
-            .downcast::<T>()
-            .map_err(|_| ComputeError::OutputTypeMismatch {
-                node: output.port.node,
-            })?;
-        Ok(*res)
-    }
-
-    /// Computes the result for a given output port using the provided context
-    ///
-    /// This function behaves similarly to [`ComputeGraph::compute`], but uses
-    /// the values given in the context as described in [`ComputationContext`].
-    ///
-    /// # Arguments
-    ///
-    /// * `output` - The output port to compute.
-    /// * `context` - Collection of values used to perform the computation,
-    ///
-    /// # Returns
-    ///
-    /// A result containing the computed boxed value or an error.
-    ///
-    /// # Errors
-    ///
-    /// An error is returned if:
-    /// - The node is not found.
-    /// - The node has the incorrect output type
-    /// - An input port of the node or a dependency of the node are not connected, and
-    ///   no value is provided via the context
-    /// - A cycle is detected in the graph.
-    #[deprecated]
-    pub fn compute_with_context<T: 'static>(
-        &self,
-        output: OutputPort<T>,
-        context: &ComputationContext,
-    ) -> Result<T, ComputeError> {
-        let res = self.compute_untyped_with(
-            output.port.clone(),
-            &ComputationOptions {
-                context: Some(context),
-            },
-            None,
-        )?;
         let res = res
             .into_any()
             .downcast::<T>()

--- a/crates/computegraph/src/lib.rs
+++ b/crates/computegraph/src/lib.rs
@@ -499,13 +499,13 @@ enum Fallback {
     Generator(FallbackGenerator),
 }
 
-/// Set predefined values for [`ComputeGraph::compute_with_context`].
+/// Set predefined values for [`ComputeGraph::compute_with`].
 ///
 /// Use this container to:
 /// - Override values passed to [`InputPort`]s
 /// - Set fallback values for unconnected [`InputPort`]s
 ///
-/// To be used with [`ComputeGraph::compute_with_context`] and [`ComputeGraph::compute_untyped_with_context`].
+/// To be used with [`ComputeGraph::compute_with`] and [`ComputeGraph::compute_untyped_with`].
 #[derive(Debug, Default)]
 pub struct ComputationContext {
     overrides: Vec<InputPortValue>,

--- a/crates/computegraph/src/lib.rs
+++ b/crates/computegraph/src/lib.rs
@@ -1173,6 +1173,8 @@ impl ComputeGraph {
     ///
     /// This function is the untyped version of [`ComputeGraph::compute`].
     ///
+    /// Use [`ComputeGraph::compute_untyped_with`] when caching or a context are needed.
+    ///
     /// # Arguments
     ///
     /// * `output` - The output port to compute.
@@ -1677,6 +1679,8 @@ impl ComputeGraph {
     }
 
     /// Computes the result for a given output port.
+    ///
+    /// Use [`ComputeGraph::compute_with`] when caching or a context are needed.
     ///
     /// # Arguments
     ///

--- a/crates/computegraph/src/lib.rs
+++ b/crates/computegraph/src/lib.rs
@@ -1661,6 +1661,7 @@ impl ComputeGraph {
     /// - An input port of the node or a dependency of the node are not connected, and
     ///   no value is provided via the context
     /// - A cycle is detected in the graph.
+    #[deprecated]
     pub fn compute_untyped_with_context(
         &self,
         output: OutputPortUntyped,
@@ -1725,6 +1726,7 @@ impl ComputeGraph {
     /// - An input port of the node or a dependency of the node are not connected, and
     ///   no value is provided via the context
     /// - A cycle is detected in the graph.
+    #[deprecated]
     pub fn compute_with_context<T: 'static>(
         &self,
         output: OutputPort<T>,

--- a/crates/computegraph/src/lib.rs
+++ b/crates/computegraph/src/lib.rs
@@ -57,7 +57,8 @@
 //! context.set_override(multiply_node.input_b(), 2);
 //!
 //! // Compute the result
-//! let result = graph.compute_with_context(multiply_node.output(), &context).unwrap();
+//! let options = ComputationOptions {context: Some(&context) };
+//! let result = graph.compute_with(multiply_node.output(), &options, None).unwrap();
 //! assert_eq!(result, (3 + 4) * 2);
 //! ```
 //!
@@ -1736,7 +1737,13 @@ impl ComputeGraph {
         output: OutputPort<T>,
         context: &ComputationContext,
     ) -> Result<T, ComputeError> {
-        let res = self.compute_untyped_with_context(output.port.clone(), context)?;
+        let res = self.compute_untyped_with(
+            output.port.clone(),
+            &ComputationOptions {
+                context: Some(context),
+            },
+            None,
+        )?;
         let res = res
             .into_any()
             .downcast::<T>()

--- a/crates/computegraph/tests/context.rs
+++ b/crates/computegraph/tests/context.rs
@@ -18,13 +18,25 @@ fn test_context_override() -> Result<()> {
     ctx.set_override(addition.input_a(), 5);
 
     assert_eq!(
-        graph.compute_with_context(addition.output(), &ctx)?,
+        graph.compute_with(
+            addition.output(),
+            &ComputationOptions {
+                context: Some(&ctx),
+            },
+            None
+        )?,
         8,
         "ctx should use the latest given value"
     );
     assert_eq!(
         *graph
-            .compute_untyped_with_context(addition.output().into(), &ctx)?
+            .compute_untyped_with(
+                addition.output().into(),
+                &ComputationOptions {
+                    context: Some(&ctx),
+                },
+                None
+            )?
             .as_ref()
             .as_any()
             .downcast_ref::<usize>()
@@ -55,7 +67,13 @@ fn test_context_override_skip_dependencies() -> Result<()> {
 
     assert_eq!(
         graph
-            .compute_with_context(addition.output(), &ctx)
+            .compute_with(
+                addition.output(),
+                &ComputationOptions {
+                    context: Some(&ctx),
+                },
+                None
+            )
             .expect("This should skip 'invalid_dep' entirely"),
         15
     );
@@ -85,10 +103,25 @@ fn test_context_fallback() -> Result<()> {
     ctx.set_fallback(5_usize);
     ctx.set_fallback(10_usize);
 
-    assert_eq!(graph.compute_with_context(addition.output(), &ctx)?, 20);
+    assert_eq!(
+        graph.compute_with(
+            addition.output(),
+            &ComputationOptions {
+                context: Some(&ctx),
+            },
+            None
+        )?,
+        20
+    );
     assert_eq!(
         *graph
-            .compute_untyped_with_context(addition.output().into(), &ctx)?
+            .compute_untyped_with(
+                addition.output().into(),
+                &ComputationOptions {
+                    context: Some(&ctx),
+                },
+                None
+            )?
             .as_ref()
             .as_any()
             .downcast_ref::<usize>()
@@ -112,10 +145,25 @@ fn test_context_fallback_generator() -> Result<()> {
     ctx.set_fallback(5_usize);
     ctx.set_fallback_generator(|_name| 10_usize);
 
-    assert_eq!(graph.compute_with_context(addition.output(), &ctx)?, 20);
+    assert_eq!(
+        graph.compute_with(
+            addition.output(),
+            &ComputationOptions {
+                context: Some(&ctx),
+            },
+            None
+        )?,
+        20
+    );
     assert_eq!(
         *graph
-            .compute_untyped_with_context(addition.output().into(), &ctx)?
+            .compute_untyped_with(
+                addition.output().into(),
+                &ComputationOptions {
+                    context: Some(&ctx),
+                },
+                None
+            )?
             .as_ref()
             .as_any()
             .downcast_ref::<usize>()
@@ -127,7 +175,6 @@ fn test_context_fallback_generator() -> Result<()> {
 
     Ok(())
 }
-
 #[test]
 fn test_context_priority() -> Result<()> {
     let mut graph = ComputeGraph::new();
@@ -144,7 +191,13 @@ fn test_context_priority() -> Result<()> {
     ctx.set_fallback(10_usize);
 
     assert_eq!(
-        graph.compute_with_context(addition.output(), &ctx)?,
+        graph.compute_with(
+            addition.output(),
+            &ComputationOptions {
+                context: Some(&ctx),
+            },
+            None
+        )?,
         1,
         "priority should be override > connected > fallback"
     );


### PR DESCRIPTION
Both variants are now superseded by  `compute_with` and `compute_untyped_with` initially added with #84.