### PR TITLE
build(opencascade-sys): use debug builds of OpenCASCADE by default

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,8 @@ resolver = "2"
 
 [workspace.dependencies]
 project = { path = "crates/project" }
+# To enable debugging of OpenCASCADE itself, use this instead:
+# opencascade-sys = { path = "crates/opencascade-sys", features = ["debug"] }
 opencascade-sys = { path = "crates/opencascade-sys" }
 occara = { path = "crates/occara" }
 viewport = { path = "crates/viewport" }

--- a/crates/opencascade-sys/Cargo.toml
+++ b/crates/opencascade-sys/Cargo.toml
@@ -14,3 +14,6 @@ publish = false
 [dependencies]
 cmake.workspace = true
 walkdir.workspace = true
+
+[features]
+debug = []


### PR DESCRIPTION
This increases runtime speed and reduces GitHub Actions Cache sizes.
Debug builds can still be enabled using the `debug` feature of `opencascade-sys`.