### PR TITLE
feat(project): add `TrackedProjectView`

### DIFF
--- a/crates/project/src/data.rs
+++ b/crates/project/src/data.rs
@@ -198,6 +198,31 @@ impl<M: Module> DataView<'_, M> {
         }));
     }
 
+    /// Plans to move this data section to another planned document.
+    ///
+    /// This will not modify the [`crate::Project`], just record this change to the
+    /// same [`ChangeBuilder`] [`crate::PlannedDocument`] was created with.
+    ///
+    /// # Arguments
+    ///
+    /// * `new_owner` - The planned document to move the data to.
+    ///
+    /// # Panics
+    /// If a [`crate::PlannedDocument`] for a different [`crate::Project`] was passed.
+    pub fn move_to_planned_document(&self, new_owner: &mut crate::PlannedDocument) {
+        assert!(
+            new_owner.cb.is_same_source_as(self),
+            "ChangeBuilder must stem from the same project"
+        );
+        new_owner
+            .cb
+            .changes
+            .push(PendingChange::Change(Change::MoveData {
+                id: self.id,
+                new_owner: Some(new_owner.id),
+            }));
+    }
+
     /// Plans to make this data section an orphan (not owned by any document).
     ///
     /// This will not modify the [`crate::Project`], just record this change to `cb`.

--- a/crates/project/src/document.rs
+++ b/crates/project/src/document.rs
@@ -30,7 +30,7 @@ impl fmt::Display for DocumentId {
 /// Document in a [`crate::Project`]
 ///
 /// Defines the metadata and the identifiers of containing data sections.
-#[derive(Debug, Serialize, Deserialize, Default, Clone)]
+#[derive(Debug, Serialize, Deserialize, Default, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Document {
     pub data: Vec<DataId>,
 }

--- a/crates/project/src/lib.rs
+++ b/crates/project/src/lib.rs
@@ -186,6 +186,7 @@ pub use document::PlannedDocument;
 pub use module_data::ModuleRegistry;
 pub use project::ProjectView;
 pub use tracked::AccessRecorder;
+pub use tracked::CacheValidator;
 pub use tracked::TrackedDataView;
 pub use tracked::TrackedDocumentView;
 pub use tracked::TrackedProjectView;

--- a/crates/project/src/lib.rs
+++ b/crates/project/src/lib.rs
@@ -158,6 +158,7 @@ mod data;
 mod document;
 mod module_data;
 mod project;
+mod tracked;
 mod user;
 
 use branch::BranchId;
@@ -184,6 +185,10 @@ pub use document::Path;
 pub use document::PlannedDocument;
 pub use module_data::ModuleRegistry;
 pub use project::ProjectView;
+pub use tracked::AccessRecorder;
+pub use tracked::TrackedDataView;
+pub use tracked::TrackedDocumentView;
+pub use tracked::TrackedProjectView;
 pub use user::UserId;
 
 /// Facilitates the deserialization of a [`Project`] from a serialized format.

--- a/crates/project/src/lib.rs
+++ b/crates/project/src/lib.rs
@@ -30,6 +30,7 @@
 //!   via a [`ModuleRegistry`].
 //! - **[`ChangeBuilder`]:** A mechanism for recording changes to be applied to a `Project`, ensuring atomicity and enabling
 //!   undo/redo.
+//! - **[`TrackedProjectView`]:** A tracked version of a [`ProjectView`] allowing implicit dependency tracking
 //!
 //! ## Usage
 //!

--- a/crates/project/src/module_data.rs
+++ b/crates/project/src/module_data.rs
@@ -62,10 +62,13 @@ impl fmt::Display for ModuleId {
 /// - `TDeserializer` - Deserializer for type-erased data
 macro_rules! define_type_erased {
     ($d:ty, $reg_entry:ident) => {
+        define_type_erased!($d, $reg_entry,);
+    };
+    ($d:ty, $reg_entry:ident, $($extra_traits:path),*) => {
         paste! {
             #[doc = "A trait shared by all [`" $d "`] types for all [`Module`]"]
             #[allow(dead_code)]
-            pub trait [<$d Trait>]: erased_serde::Serialize + Debug + Send + Sync + Any + DynClone {
+            pub trait [<$d Trait>]: erased_serde::Serialize + Debug + Send + Sync + Any + DynClone $(+ $extra_traits)* {
                 /// Provides read-only access to the underlying data type.
                 fn as_any(&self) -> &dyn Any;
                 /// Provides mutable access to the underlying data type.

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -34,6 +34,12 @@ impl ProjectSource for ProjectView {
     }
 }
 
+impl ProjectSource for std::sync::Arc<ProjectView> {
+    fn uuid(&self) -> uuid::Uuid {
+        self.uuid
+    }
+}
+
 impl ProjectView {
     /// Opens a read only [`DocumentView`].
     ///

--- a/crates/project/src/tracked.rs
+++ b/crates/project/src/tracked.rs
@@ -444,8 +444,8 @@ impl<'a, M: Module> TrackedDataView<'a, M> {
     ///
     /// # Panics
     /// If a [`ChangeBuilder`] of a different [`crate::Project`] was passed.
-    pub fn move_to_document(&self, new_owner: &crate::DocumentView, cb: &mut ChangeBuilder) {
-        self.0.move_to_document(new_owner, cb);
+    pub fn move_to_document(&self, new_owner: &crate::TrackedDocumentView, cb: &mut ChangeBuilder) {
+        self.0.move_to_document(&new_owner.0, cb);
     }
 
     /// Plans to make this data section an orphan (not owned by any document).

--- a/crates/project/src/tracked.rs
+++ b/crates/project/src/tracked.rs
@@ -1,0 +1,202 @@
+use crate::{
+    ChangeBuilder, DataId, DataView, DocumentId, DocumentView, Path, PlannedData, PlannedDocument,
+    ProjectSource, ProjectView,
+};
+use module::{DataSection, Module};
+use std::sync::{Arc, Mutex};
+use uuid::Uuid;
+
+#[expect(dead_code)]
+#[derive(Debug, Clone)]
+enum AccessEvent {
+    OpenDocument(DocumentId),
+    OpenDataById(DataId),
+    AccessPesistent(DataId),
+    AccessPesistentUser(DataId),
+    AccessShared(DataId),
+    AccessSession(DataId),
+}
+
+#[derive(Clone, Debug)]
+pub struct AccessRecorder(Arc<Mutex<Vec<AccessEvent>>>);
+
+impl AccessRecorder {
+    fn track(&self, access: AccessEvent) {
+        self.0.lock().unwrap().push(access);
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct TrackedProjectView(Arc<ProjectView>, AccessRecorder);
+
+impl ProjectSource for TrackedProjectView {
+    fn uuid(&self) -> Uuid {
+        self.0.uuid
+    }
+}
+
+impl TrackedProjectView {
+    #[must_use]
+    pub fn new(pv: Arc<ProjectView>) -> (Self, AccessRecorder) {
+        let accesses = AccessRecorder(Arc::new(Mutex::new(Vec::new())));
+        (Self(pv, accesses.clone()), accesses)
+    }
+
+    #[must_use]
+    pub fn open_document(&self, document_id: DocumentId) -> Option<TrackedDocumentView> {
+        self.1.track(AccessEvent::OpenDocument(document_id));
+        self.0
+            .open_document(document_id)
+            .map(|d| TrackedDocumentView(d, self.1.clone()))
+    }
+
+    #[must_use]
+    pub fn create_document<'b, 'c>(
+        &'b self,
+        cb: &'c mut ChangeBuilder,
+        path: Path,
+    ) -> PlannedDocument<'b, 'c> {
+        self.0.create_document(cb, path)
+    }
+
+    pub fn create_data<M: Module>(&self, cb: &mut ChangeBuilder) -> DataId {
+        self.0.create_data::<M>(cb)
+    }
+
+    #[must_use]
+    pub fn open_data_by_id<M: Module>(&self, data_id: DataId) -> Option<TrackedDataView<M>> {
+        self.1.track(AccessEvent::OpenDataById(data_id));
+        self.0
+            .open_data_by_id(data_id)
+            .map(|d| TrackedDataView(d, self.1.clone()))
+    }
+
+    pub fn open_data_by_type<M: Module>(&self) -> impl Iterator<Item = TrackedDataView<M>> + '_ {
+        self.0
+            .open_data_by_type()
+            .map(|d| TrackedDataView(d, self.1.clone()))
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct TrackedDocumentView<'a>(DocumentView<'a>, AccessRecorder);
+
+impl ProjectSource for TrackedDocumentView<'_> {
+    fn uuid(&self) -> Uuid {
+        self.0.uuid
+    }
+}
+
+impl From<TrackedDocumentView<'_>> for DocumentId {
+    fn from(dv: TrackedDocumentView<'_>) -> Self {
+        dv.0.id
+    }
+}
+
+impl TrackedDocumentView<'_> {
+    #[must_use]
+    pub fn open_data_by_id<M: Module>(&self, data_id: DataId) -> Option<TrackedDataView<M>> {
+        self.0
+            .open_data_by_id(data_id)
+            .map(|d| TrackedDataView(d, self.1.clone()))
+    }
+
+    pub fn open_data_by_type<M: Module>(&self) -> impl Iterator<Item = TrackedDataView<M>> + '_ {
+        self.0
+            .open_data_by_type()
+            .map(|d| TrackedDataView(d, self.1.clone()))
+    }
+
+    #[must_use]
+    pub fn create_data<'b, 'c, M: Module>(
+        &'b self,
+        cb: &'c mut ChangeBuilder,
+    ) -> PlannedData<'b, 'c, M> {
+        self.0.create_data(cb)
+    }
+
+    pub fn delete(&self, cb: &mut ChangeBuilder) {
+        self.0.delete(cb);
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct TrackedDataView<'a, M: Module>(DataView<'a, M>, AccessRecorder);
+
+impl<M: Module> ProjectSource for TrackedDataView<'_, M> {
+    fn uuid(&self) -> Uuid {
+        self.0.uuid
+    }
+}
+
+impl<M: Module> From<TrackedDataView<'_, M>> for DataId {
+    fn from(dv: TrackedDataView<'_, M>) -> Self {
+        dv.0.id
+    }
+}
+
+impl<'a, M: Module> TrackedDataView<'a, M> {
+    pub fn apply_persistent(
+        &self,
+        args: <M::PersistentData as DataSection>::Args,
+        cb: &mut ChangeBuilder,
+    ) {
+        self.0.apply_persistent(args, cb);
+    }
+
+    pub fn apply_persistent_user(
+        &self,
+        args: <M::PersistentUserData as DataSection>::Args,
+        cb: &mut ChangeBuilder,
+    ) {
+        self.0.apply_persistent_user(args, cb);
+    }
+
+    pub fn apply_session(
+        &self,
+        args: <M::SessionData as DataSection>::Args,
+        cb: &mut ChangeBuilder,
+    ) {
+        self.0.apply_session(args, cb);
+    }
+
+    pub fn apply_shared(&self, args: <M::SharedData as DataSection>::Args, cb: &mut ChangeBuilder) {
+        self.0.apply_shared(args, cb);
+    }
+
+    pub fn delete(&self, cb: &mut ChangeBuilder) {
+        self.0.delete(cb);
+    }
+
+    pub fn move_to_document(&self, new_owner: &crate::DocumentView, cb: &mut ChangeBuilder) {
+        self.0.move_to_document(new_owner, cb);
+    }
+
+    pub fn make_orphan(&self, cb: &mut ChangeBuilder) {
+        self.0.make_orphan(cb);
+    }
+
+    #[must_use]
+    pub fn persistent(&self) -> &'a &<M as Module>::PersistentData {
+        self.1.track(AccessEvent::AccessPesistent(self.0.id));
+        &self.0.persistent
+    }
+
+    #[must_use]
+    pub fn persistent_user(&self) -> &'a &<M as Module>::PersistentUserData {
+        self.1.track(AccessEvent::AccessPesistentUser(self.0.id));
+        &self.0.persistent_user
+    }
+
+    #[must_use]
+    pub fn shared_data(&self) -> &'a &<M as Module>::SharedData {
+        self.1.track(AccessEvent::AccessShared(self.0.id));
+        &self.0.shared_data
+    }
+
+    #[must_use]
+    pub fn session_data(&self) -> &'a &<M as Module>::SessionData {
+        self.1.track(AccessEvent::AccessSession(self.0.id));
+        &self.0.session_data
+    }
+}

--- a/crates/project/src/tracked.rs
+++ b/crates/project/src/tracked.rs
@@ -521,6 +521,21 @@ impl<'a, M: Module> TrackedDataView<'a, M> {
         self.0.move_to_document(&new_owner.0, cb);
     }
 
+    /// Plans to move this data section to another planned document.
+    ///
+    /// This will not modify the [`crate::Project`], just record this change to the
+    /// same [`ChangeBuilder`] [`crate::PlannedDocument`] was created with.
+    ///
+    /// # Arguments
+    ///
+    /// * `new_owner` - The planned document to move the data to.
+    ///
+    /// # Panics
+    /// If a [`crate::PlannedDocument`] for a different [`crate::Project`] was passed.
+    pub fn move_to_planned_document(&self, new_owner: &mut crate::PlannedDocument) {
+        self.0.move_to_planned_document(new_owner);
+    }
+
     /// Plans to make this data section an orphan (not owned by any document).
     ///
     /// This will not modify the [`crate::Project`], just record this change to `cb`.

--- a/crates/project/tests/thread_safety.rs
+++ b/crates/project/tests/thread_safety.rs
@@ -16,4 +16,10 @@ fn test_send_sync() {
     assert_send_sync::<ProjectView>();
     assert_send_sync::<DocumentView<'_>>();
     assert_send_sync::<DataView<'_, MinimalTestModule>>();
+
+    assert_send_sync::<CacheValidator>();
+    assert_send_sync::<AccessRecorder>();
+    assert_send_sync::<TrackedProjectView>();
+    assert_send_sync::<TrackedDocumentView<'_>>();
+    assert_send_sync::<TrackedDataView<'_, MinimalTestModule>>();
 }

--- a/crates/project/tests/tracked.rs
+++ b/crates/project/tests/tracked.rs
@@ -1,0 +1,269 @@
+mod common;
+use common::{minimal_test_module::MinimalTestModule, setup_project};
+use project::*;
+use std::sync::Arc;
+
+#[test]
+fn test_tracked_view_not_accessed() {
+    let mut reg = ModuleRegistry::new();
+    reg.register::<MinimalTestModule>();
+
+    let mut project = Project::new();
+    {
+        let mut cb = ChangeBuilder::from(&project);
+        let view = project.create_view(&reg).unwrap();
+        let _ = view.create_data::<MinimalTestModule>(&mut cb);
+        project.apply_changes(cb, &reg).unwrap();
+    }
+
+    let view = Arc::new(project.create_view(&reg).unwrap());
+    let (_tracked_view, recorder) = TrackedProjectView::new(view);
+
+    let validator = recorder.freeze();
+    assert!(!validator.was_accessed());
+}
+
+#[test]
+fn test_tracked_view_basic_access() {
+    let mut reg = ModuleRegistry::new();
+    reg.register::<MinimalTestModule>();
+
+    let mut project = Project::new();
+    let data_id;
+    {
+        let mut cb = ChangeBuilder::from(&project);
+        let view = project.create_view(&reg).unwrap();
+        data_id = view.create_data::<MinimalTestModule>(&mut cb);
+        project.apply_changes(cb, &reg).unwrap();
+    }
+
+    let view = Arc::new(project.create_view(&reg).unwrap());
+    let (tracked_view, recorder) = TrackedProjectView::new(view);
+
+    // Access data to generate tracking events
+    let _data = tracked_view
+        .open_data_by_id::<MinimalTestModule>(data_id)
+        .unwrap();
+
+    let validator = recorder.freeze();
+    assert!(validator.was_accessed());
+}
+
+#[test]
+fn test_document_operations() {
+    let p = setup_project();
+    let view = Arc::new(p.view());
+    let (tracked_view, recorder) = TrackedProjectView::new(view.clone());
+
+    // Test document creation
+    let mut cb = ChangeBuilder::from(&p.project);
+    let _new_doc =
+        tracked_view.create_document(&mut cb, Path::new("/new_doc".to_string()).unwrap());
+
+    // Test document access and data operations within document
+    let doc = tracked_view.open_document(p.doc1).unwrap();
+    let data_by_type: Vec<_> = doc.open_data_by_type::<MinimalTestModule>().collect();
+    assert!(!data_by_type.is_empty());
+
+    // Test document data access by ID
+    let data = doc
+        .open_data_by_id::<MinimalTestModule>(p.doc1_minimal_data)
+        .unwrap();
+    assert_eq!(data.session_data().num, 10);
+
+    let validator = recorder.freeze();
+    assert!(validator.was_accessed());
+}
+
+#[test]
+fn test_data_operations() {
+    let p = setup_project();
+    let view = Arc::new(p.view());
+    let (tracked_view, recorder) = TrackedProjectView::new(view.clone());
+
+    // Test different ways to access data
+    let by_id = tracked_view.open_data_by_id::<MinimalTestModule>(p.doc1_minimal_data);
+    assert!(by_id.is_some());
+
+    let by_type: Vec<_> = tracked_view
+        .open_data_by_type::<MinimalTestModule>()
+        .collect();
+    assert!(!by_type.is_empty());
+
+    let validator = recorder.freeze();
+    assert!(validator.was_accessed());
+}
+
+#[test]
+fn test_different_project_validation() {
+    let p1 = setup_project();
+    let p2 = setup_project();
+
+    let view1 = Arc::new(p1.view());
+    let view2 = Arc::new(p2.view());
+
+    let (tracked_view, recorder) = TrackedProjectView::new(view1.clone());
+
+    // Generate some access events
+    let _doc = tracked_view.open_document(p1.doc1);
+
+    let validator = recorder.freeze();
+
+    // Should be invalid for different projects
+    assert!(!validator.is_cache_valid(&view1, &view2));
+}
+
+#[test]
+fn test_cache_validation_open_data_by_type() {
+    let mut p = setup_project();
+    let view = Arc::new(p.view());
+    let (tracked_view, recorder) = TrackedProjectView::new(view.clone());
+
+    // Access data by type to generate tracking event
+    let data_list: Vec<_> = tracked_view
+        .open_data_by_type::<MinimalTestModule>()
+        .collect();
+    assert!(!data_list.is_empty());
+
+    let validator = recorder.freeze();
+    assert!(validator.is_cache_valid(&view, &view));
+
+    // Create new data of same type
+    let mut cb = ChangeBuilder::from(&view);
+    tracked_view.create_data::<MinimalTestModule>(&mut cb);
+    p.project.apply_changes(cb, &p.reg).unwrap();
+    let new_view = p.view();
+
+    // Cache should be invalid as the list of data of this type changed
+    assert!(!validator.is_cache_valid(&view, &new_view));
+}
+
+#[test]
+fn test_cache_validation_document_data_by_id() {
+    let mut p = setup_project();
+    let view = Arc::new(p.view());
+    let (tracked_view, recorder) = TrackedProjectView::new(view.clone());
+
+    // Access document data by ID
+    let doc = tracked_view.open_document(p.doc1).unwrap();
+    let data = doc
+        .open_data_by_id::<MinimalTestModule>(p.doc1_minimal_data)
+        .unwrap();
+    let _session = data.session_data(); // Access some data to ensure it's tracked
+
+    let validator = recorder.freeze();
+    assert!(validator.is_cache_valid(&view, &view));
+
+    // Move data to different document
+    let mut cb = ChangeBuilder::from(&view);
+    let mut new_doc =
+        tracked_view.create_document(&mut cb, Path::new("/new_doc".to_string()).unwrap());
+    data.move_to_planned_document(&mut new_doc);
+    p.project.apply_changes(cb, &p.reg).unwrap();
+    let new_view = p.view();
+
+    // Cache should be invalid as the data moved documents
+    assert!(!validator.is_cache_valid(&view, &new_view));
+}
+
+#[test]
+fn test_cache_validation_document_data_by_type() {
+    let mut p = setup_project();
+    let view = Arc::new(p.view());
+    let (tracked_view, recorder) = TrackedProjectView::new(view.clone());
+
+    // Access document data by type
+    let doc = tracked_view.open_document(p.doc1).unwrap();
+    let data_list: Vec<_> = doc.open_data_by_type::<MinimalTestModule>().collect();
+    assert!(!data_list.is_empty());
+
+    let validator = recorder.freeze();
+    assert!(validator.is_cache_valid(&view, &view));
+
+    // Add new data of same type to document
+    let mut cb = ChangeBuilder::from(&view);
+    let _data = doc.create_data::<MinimalTestModule>(&mut cb);
+    p.project.apply_changes(cb, &p.reg).unwrap();
+    let new_view = p.view();
+
+    // Cache should be invalid as document's data list changed
+    assert!(!validator.is_cache_valid(&view, &new_view));
+}
+
+#[test]
+fn test_cache_validation_complex_scenario() {
+    let mut p = setup_project();
+    let view = Arc::new(p.view());
+    let (tracked_view, recorder) = TrackedProjectView::new(view.clone());
+
+    // Generate multiple types of access events
+    let doc = tracked_view.open_document(p.doc1).unwrap();
+
+    // Access by type globally
+    let _global_data: Vec<_> = tracked_view
+        .open_data_by_type::<MinimalTestModule>()
+        .collect();
+
+    // Access by type in document
+    let _doc_data: Vec<_> = doc.open_data_by_type::<MinimalTestModule>().collect();
+
+    // Access specific data
+    let data = doc
+        .open_data_by_id::<MinimalTestModule>(p.doc1_minimal_data)
+        .unwrap();
+    let _session = data.session_data();
+
+    let validator = recorder.freeze();
+    assert!(validator.is_cache_valid(&view, &view));
+
+    // Make various modifications
+    let mut cb = ChangeBuilder::from(&view);
+
+    // Create new data
+    let _new_data_id = tracked_view.create_data::<MinimalTestModule>(&mut cb);
+
+    // Move existing data
+    let mut new_doc =
+        tracked_view.create_document(&mut cb, Path::new("/new_doc".to_string()).unwrap());
+    data.move_to_planned_document(&mut new_doc);
+
+    // Modify data content
+    data.apply_session(42, &mut cb);
+
+    p.project.apply_changes(cb, &p.reg).unwrap();
+    let new_view = p.view();
+
+    // Cache should be invalid due to multiple changes
+    assert!(!validator.is_cache_valid(&view, &new_view));
+}
+
+#[test]
+fn test_cache_validation_edge_cases() {
+    // Create two separate projects to get valid but non-existent IDs
+    let mut p1 = setup_project();
+    let p2 = setup_project();
+
+    let view = Arc::new(p1.view());
+    let (tracked_view, recorder) = TrackedProjectView::new(view.clone());
+
+    // Test with document that exists in p2 but not in p1
+    let _missing_doc = tracked_view.open_document(p2.doc1);
+
+    // Test with non-existent data (using data ID from p2)
+    let doc = tracked_view.open_document(p1.doc1).unwrap();
+    let _missing_data = doc.open_data_by_id::<MinimalTestModule>(p2.doc1_minimal_data);
+
+    // Test with empty data type list
+    let _empty_list = doc.open_data_by_type::<MinimalTestModule>();
+
+    let validator = recorder.freeze();
+
+    // Modify project
+    let mut cb = ChangeBuilder::from(&view);
+    let _data = doc.create_data::<MinimalTestModule>(&mut cb);
+    p1.project.apply_changes(cb, &p1.reg).unwrap();
+    let new_view = p1.view();
+
+    // Validate cache with edge cases
+    assert!(!validator.is_cache_valid(&view, &new_view));
+}


### PR DESCRIPTION
This PR implements tracked variants of `ProjectView`, `DocumentView` and `DataView`.
These allow the creation of a `CacheValidator` to individually (implicitly) decide if a cache is still valid for a deterministic function after the `Project` was updated.
This provides the basis for implementing #48 and #49.

Closes #46 