### PR TITLE
feat(viewport): add caching support for Viewports

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1931,6 +1931,7 @@ dependencies = [
  "iced_core",
  "log",
  "rustc-hash 2.0.0",
+ "tokio",
  "wasm-bindgen-futures",
  "wasm-timer",
 ]
@@ -4045,6 +4046,16 @@ name = "tinyvec_macros"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
+name = "tokio"
+version = "1.43.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d61fa4ffa3de412bfea335c6ecff681de2b609ba3c77ef3e00e521813a9ed9e"
+dependencies = [
+ "backtrace",
+ "pin-project-lite",
+]
 
 [[package]]
 name = "toml_datetime"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ modeling-workspace = { path = "crates/modeling-workspace" }
 modeling-module = { path = "crates/modeling-module" }
 wasm-libc = { path = "crates/wasm-libc" }
 
-iced = { version = "0.13", features = ["advanced", "webgl"] }
+iced = { version = "0.13", features = ["advanced", "webgl", "tokio"] }
 tracing-subscriber = "0.3"
 thiserror = "1.0"
 dyn-clone = "1.0"

--- a/crates/cadara/src/lib.rs
+++ b/crates/cadara/src/lib.rs
@@ -3,12 +3,18 @@
 #![allow(clippy::module_name_repetitions)]
 #![allow(clippy::cognitive_complexity)]
 
+use iced::{time, Subscription};
 use modeling_module::ModelingModule;
 use std::sync::Arc;
 use workspace::Workspace;
 
 struct App {
     viewport: viewport::Viewport,
+    project: project::Project,
+    project_view: Arc<project::ProjectView>,
+    data_uuid: project::DataId,
+    reg: project::ModuleRegistry,
+    tick_counter: u32,
 }
 
 impl Default for App {
@@ -18,7 +24,9 @@ impl Default for App {
 }
 
 #[derive(Debug)]
-enum Message {}
+enum Message {
+    Tick,
+}
 
 impl App {
     fn new() -> Self {
@@ -46,16 +54,61 @@ impl App {
 
         let project_view = Arc::new(project.create_view(&reg).unwrap());
 
-        let mut viewport = viewport::Viewport::new(project_view);
+        let mut viewport = viewport::Viewport::new(project_view.clone());
         let workspace = modeling_workspace::ModelingWorkspace { data_uuid };
         // TODO: this should dynamically select the first fitting plugin
         let plugin = workspace.viewport_plugins()[0].clone();
         viewport.pipeline.add_dynamic_plugin(plugin).unwrap();
-        Self { viewport }
+        Self {
+            viewport,
+            project,
+            project_view,
+            data_uuid,
+            reg,
+            tick_counter: 0,
+        }
     }
 
-    #[expect(clippy::unused_self)] // required by `iced::application`
-    fn update(&mut self, _message: Message) {}
+    #[expect(clippy::needless_pass_by_value, reason = "required by iced")]
+    fn update(&mut self, message: Message) {
+        match message {
+            Message::Tick => {
+                let data = self
+                    .project_view
+                    .open_data_by_id::<ModelingModule>(self.data_uuid)
+                    .unwrap();
+
+                let mut cb = project::ChangeBuilder::from(&data);
+                if self.tick_counter > 100 {
+                    data.apply_persistent(
+                        modeling_module::persistent_data::ModelingTransaction::Create(
+                            modeling_module::persistent_data::Create {
+                                before: None,
+                                operation: modeling_module::operation::ModelingOperation::Grow,
+                            },
+                        ),
+                        &mut cb,
+                    );
+
+                    println!("grow");
+                    self.tick_counter = 0;
+                } else {
+                    let data = self
+                        .project_view
+                        .open_data_by_id::<ModelingModule>(self.data_uuid)
+                        .unwrap();
+
+                    let mut cb = project::ChangeBuilder::from(&data);
+
+                    data.apply_session((), &mut cb);
+                }
+                self.project.apply_changes(cb, &self.reg).unwrap();
+                self.project_view = Arc::new(self.project.create_view(&self.reg).unwrap());
+                self.viewport.update(self.project_view.clone());
+                self.tick_counter += 1;
+            }
+        }
+    }
 
     fn view(&self) -> iced::Element<'_, Message> {
         let viewport_shader = iced::widget::shader(&self.viewport)
@@ -63,6 +116,11 @@ impl App {
             .height(iced::Length::Fill);
 
         iced::widget::column!(iced::widget::text("Viewport:"), viewport_shader).into()
+    }
+
+    #[expect(clippy::unused_self)]
+    fn subscription(&self) -> Subscription<Message> {
+        time::every(time::Duration::from_millis(20)).map(|_| Message::Tick)
     }
 }
 
@@ -86,6 +144,7 @@ pub fn run_cadara() {
     tracing_subscriber::fmt::init();
 
     iced::application("CADara", App::update, App::view)
+        .subscription(App::subscription)
         .run()
         .unwrap();
 }

--- a/crates/cadara/src/lib.rs
+++ b/crates/cadara/src/lib.rs
@@ -4,6 +4,7 @@
 #![allow(clippy::cognitive_complexity)]
 
 use modeling_module::ModelingModule;
+use std::sync::Arc;
 use workspace::Workspace;
 
 struct App {
@@ -43,7 +44,7 @@ impl App {
         );
         project.apply_changes(cb, &reg).unwrap();
 
-        let project_view = project.create_view(&reg).unwrap();
+        let project_view = Arc::new(project.create_view(&reg).unwrap());
 
         let mut viewport = viewport::Viewport::new(project_view);
         let workspace = modeling_workspace::ModelingWorkspace { data_uuid };

--- a/crates/modeling-module/src/operation.rs
+++ b/crates/modeling-module/src/operation.rs
@@ -7,4 +7,6 @@ pub mod sketch;
 pub enum ModelingOperation {
     Sketch(sketch::Sketch),
     Extrude(extrude::Extrude),
+    Grow,
+    Shrink,
 }

--- a/crates/modeling-module/src/persistent_data.rs
+++ b/crates/modeling-module/src/persistent_data.rs
@@ -11,7 +11,6 @@ use uuid::Uuid;
 pub struct Step {
     name: String,
     operation: ModelingOperation,
-    uuid: Uuid,
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
@@ -38,11 +37,9 @@ impl DataSection for PersistentData {
     fn apply(&mut self, args: Self::Args) {
         match args {
             ModelingTransaction::Create(c) => {
-                let uuid = Uuid::new_v4();
                 self.steps.push(Step {
                     name: "new operation".to_string(),
                     operation: c.operation,
-                    uuid,
                 });
             }
             ModelingTransaction::Update => todo!(),

--- a/crates/modeling-module/src/persistent_data.rs
+++ b/crates/modeling-module/src/persistent_data.rs
@@ -58,11 +58,27 @@ impl DataSection for PersistentData {
 impl PersistentData {
     #[must_use]
     pub fn shape(&self) -> occara::shape::Shape {
+        let mut scale = 1.0;
+        for _ in self
+            .steps
+            .iter()
+            .filter(|s| matches!(s.operation, ModelingOperation::Grow))
+        {
+            scale *= 1.02;
+        }
+
+        for _ in self
+            .steps
+            .iter()
+            .filter(|s| matches!(s.operation, ModelingOperation::Shrink))
+        {
+            scale /= 1.02;
+        }
         let wire = {
             let p1 = Point::new(0.0, 0.0, 0.0);
-            let p2 = Point::new(0.0, 1.0, 0.0);
-            let p3 = Point::new(1.0, 1.0, 0.0);
-            let p4 = Point::new(1.0, 0.0, 0.0);
+            let p2 = Point::new(0.0, scale, 0.0);
+            let p3 = Point::new(scale, scale, 0.0);
+            let p4 = Point::new(scale, 0.0, 0.0);
             Wire::new(&[
                 &Edge::line(&p1, &p2),
                 &Edge::line(&p2, &p3),
@@ -70,7 +86,7 @@ impl PersistentData {
                 &Edge::line(&p4, &p1),
             ])
         };
-        let b = wire.face().extrude(&Vector::new(0.0, 0.0, 1.0));
+        let b = wire.face().extrude(&Vector::new(0.0, 0.0, scale));
 
         let mut f = b.fillet();
         for e in b.edges() {

--- a/crates/modeling-workspace/src/viewport.rs
+++ b/crates/modeling-workspace/src/viewport.rs
@@ -1,5 +1,5 @@
 use computegraph::{node, ComputeGraph};
-use viewport::{RenderNodePorts, SceneGraphBuilder, UpdateNodePorts};
+use viewport::{ProjectState, RenderNodePorts, SceneGraphBuilder, UpdateNodePorts};
 
 mod camera;
 mod rendering;
@@ -15,10 +15,7 @@ pub struct ModelingViewportPlugin {
 }
 
 #[node(ModelingViewportPlugin -> (scene, output))]
-fn run(
-    &self,
-    _project: &project::ProjectView,
-) -> (viewport::SceneGraph, ModelingViewportPluginOutput) {
+fn run(&self, _project: &ProjectState) -> (viewport::SceneGraph, ModelingViewportPluginOutput) {
     let mut graph = ComputeGraph::new();
     let model_node = graph
         .add_node(

--- a/crates/modeling-workspace/src/viewport/scene_nodes.rs
+++ b/crates/modeling-workspace/src/viewport/scene_nodes.rs
@@ -1,6 +1,7 @@
 use computegraph::node;
 use iced::widget::shader;
-use viewport::ViewportEvent;
+use project::TrackedDataView;
+use viewport::{ProjectState, ViewportEvent};
 
 use super::{
     rendering::{MeshData, RenderPrimitive, Vertex},
@@ -13,11 +14,11 @@ pub struct ModelNode {
 }
 
 #[node(ModelNode -> !)]
-fn run(&self, project: &project::ProjectView) -> occara::shape::Shape {
-    let data_view: project::DataView<modeling_module::ModelingModule> =
+fn run(&self, project: &ProjectState) -> occara::shape::Shape {
+    let data_view: TrackedDataView<modeling_module::ModelingModule> =
         project.open_data_by_id(self.data_uuid).unwrap();
 
-    data_view.persistent.shape()
+    data_view.persistent().shape()
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -64,10 +65,10 @@ fn run(
     &self,
     event: &ViewportEvent,
     state: &ViewportState,
-    project: &project::ProjectView,
+    project: &ProjectState,
 ) -> ViewportState {
     let mut state = (*state).clone();
-    let _data_view: project::DataView<modeling_module::ModelingModule> =
+    let _data_view: TrackedDataView<modeling_module::ModelingModule> =
         project.open_data_by_id(self.data_uuid).unwrap();
     if let shader::Event::Mouse(m) = event.event {
         match m {

--- a/crates/viewport/src/lib.rs
+++ b/crates/viewport/src/lib.rs
@@ -56,8 +56,8 @@ mod pipeline;
 
 #[doc(inline)]
 pub use pipeline::{
-    DynamicViewportPlugin, ExecuteError, PipelineAddError, RenderNodePorts, SceneGraph,
-    SceneGraphBuilder, UpdateNodePorts, ViewportPipeline, ViewportPlugin,
+    DynamicViewportPlugin, ExecuteError, PipelineAddError, ProjectState, RenderNodePorts,
+    SceneGraph, SceneGraphBuilder, UpdateNodePorts, ViewportPipeline, ViewportPlugin,
     ViewportPluginValidationError,
 };
 

--- a/crates/viewport/src/lib.rs
+++ b/crates/viewport/src/lib.rs
@@ -82,10 +82,10 @@ pub struct Viewport {
 
 impl Viewport {
     #[must_use]
-    pub fn new(project_view: ProjectView) -> Self {
+    pub fn new(project_view: Arc<ProjectView>) -> Self {
         Self {
             pipeline: ViewportPipeline::default(),
-            project_view: Arc::new(project_view),
+            project_view,
             project_view_version: 1,
         }
     }

--- a/crates/viewport/src/lib.rs
+++ b/crates/viewport/src/lib.rs
@@ -57,8 +57,8 @@ mod pipeline;
 #[doc(inline)]
 pub use pipeline::{
     DynamicViewportPlugin, ExecuteError, PipelineAddError, ProjectState, RenderNodePorts,
-    SceneGraph, SceneGraphBuilder, UpdateNodePorts, ViewportPipeline, ViewportPlugin,
-    ViewportPluginValidationError,
+    SceneGraph, SceneGraphBuilder, UpdateNodePorts, ViewportPipeline, ViewportPipelineCache,
+    ViewportPlugin, ViewportPluginValidationError,
 };
 
 #[derive(Debug)]

--- a/crates/viewport/src/lib.rs
+++ b/crates/viewport/src/lib.rs
@@ -77,6 +77,7 @@ pub struct ViewportState {
 pub struct Viewport {
     pub pipeline: ViewportPipeline,
     pub project_view: Arc<ProjectView>,
+    pub prev_project_view: Option<Arc<ProjectView>>,
     pub project_view_version: u64,
 }
 
@@ -86,12 +87,13 @@ impl Viewport {
         Self {
             pipeline: ViewportPipeline::default(),
             project_view,
+            prev_project_view: None,
             project_view_version: 1,
         }
     }
 
     pub fn update(&mut self, project_view: Arc<ProjectView>) {
-        self.project_view = project_view;
+        self.prev_project_view = Some(std::mem::replace(&mut self.project_view, project_view));
         self.project_view_version += 1;
     }
 }
@@ -138,6 +140,7 @@ impl<Message> shader::Program<Message> for Viewport {
             pipeline: self.pipeline.clone(),
             state: state.clone(),
             project_view: self.project_view.clone(),
+            prev_project_view: self.prev_project_view.clone(),
             project_view_version: self.project_view_version,
         }
     }
@@ -157,6 +160,7 @@ pub struct ShaderPrimitive {
     pub pipeline: ViewportPipeline,
     pub state: ViewportState,
     pub project_view: Arc<ProjectView>,
+    pub prev_project_view: Option<Arc<ProjectView>>,
     pub project_view_version: u64,
 }
 

--- a/crates/viewport/src/lib.rs
+++ b/crates/viewport/src/lib.rs
@@ -57,7 +57,7 @@ mod pipeline;
 #[doc(inline)]
 pub use pipeline::{
     DynamicViewportPlugin, ExecuteError, PipelineAddError, ProjectState, RenderNodePorts,
-    SceneGraph, SceneGraphBuilder, UpdateNodePorts, ViewportPipeline, ViewportPipelineCache,
+    SceneGraph, SceneGraphBuilder, UpdateNodePorts, ViewportCache, ViewportPipeline,
     ViewportPlugin, ViewportPluginValidationError,
 };
 

--- a/crates/viewport/src/lib.rs
+++ b/crates/viewport/src/lib.rs
@@ -89,6 +89,11 @@ impl Viewport {
             project_view_version: 1,
         }
     }
+
+    pub fn update(&mut self, project_view: Arc<ProjectView>) {
+        self.project_view = project_view;
+        self.project_view_version += 1;
+    }
 }
 
 impl<Message> shader::Program<Message> for Viewport {

--- a/crates/viewport/src/lib.rs
+++ b/crates/viewport/src/lib.rs
@@ -76,7 +76,7 @@ pub struct ViewportState {
 #[derive(Clone)]
 pub struct Viewport {
     pub pipeline: ViewportPipeline,
-    pub project_view: ProjectView,
+    pub project_view: Arc<ProjectView>,
 }
 
 impl Viewport {
@@ -84,7 +84,7 @@ impl Viewport {
     pub fn new(project_view: ProjectView) -> Self {
         Self {
             pipeline: ViewportPipeline::default(),
-            project_view,
+            project_view: Arc::new(project_view),
         }
     }
 }
@@ -147,7 +147,7 @@ impl<Message> shader::Program<Message> for Viewport {
 pub struct ShaderPrimitive {
     pub pipeline: ViewportPipeline,
     pub state: ViewportState,
-    pub project_view: ProjectView,
+    pub project_view: Arc<ProjectView>,
 }
 
 impl shader::Primitive for ShaderPrimitive {

--- a/crates/viewport/src/lib.rs
+++ b/crates/viewport/src/lib.rs
@@ -77,6 +77,7 @@ pub struct ViewportState {
 pub struct Viewport {
     pub pipeline: ViewportPipeline,
     pub project_view: Arc<ProjectView>,
+    pub project_view_version: u64,
 }
 
 impl Viewport {
@@ -85,6 +86,7 @@ impl Viewport {
         Self {
             pipeline: ViewportPipeline::default(),
             project_view: Arc::new(project_view),
+            project_view_version: 1,
         }
     }
 }
@@ -115,6 +117,7 @@ impl<Message> shader::Program<Message> for Viewport {
                 &mut state.state.lock().unwrap(),
                 event,
                 self.project_view.clone(),
+                self.project_view_version,
             )
             .unwrap();
         (iced::advanced::graphics::core::event::Status::Ignored, None)
@@ -130,6 +133,7 @@ impl<Message> shader::Program<Message> for Viewport {
             pipeline: self.pipeline.clone(),
             state: state.clone(),
             project_view: self.project_view.clone(),
+            project_view_version: self.project_view_version,
         }
     }
 
@@ -148,6 +152,7 @@ pub struct ShaderPrimitive {
     pub pipeline: ViewportPipeline,
     pub state: ViewportState,
     pub project_view: Arc<ProjectView>,
+    pub project_view_version: u64,
 }
 
 impl shader::Primitive for ShaderPrimitive {
@@ -165,6 +170,7 @@ impl shader::Primitive for ShaderPrimitive {
             .compute_primitive(
                 &mut self.state.state.lock().unwrap(),
                 self.project_view.clone(),
+                self.project_view_version,
             )
             .unwrap();
         a.prepare(device, queue, format, storage, bounds, viewport);
@@ -182,6 +188,7 @@ impl shader::Primitive for ShaderPrimitive {
             .compute_primitive(
                 &mut self.state.state.lock().unwrap(),
                 self.project_view.clone(),
+                self.project_view_version,
             )
             .unwrap();
         a.render(encoder, storage, target, clip_bounds);

--- a/crates/viewport/src/lib.rs
+++ b/crates/viewport/src/lib.rs
@@ -92,6 +92,7 @@ impl Viewport {
         }
     }
 
+    /// Update the viewport with a new version of the [`ProjectView`].
     pub fn update(&mut self, project_view: Arc<ProjectView>) {
         self.prev_project_view = Some(std::mem::replace(&mut self.project_view, project_view));
         self.project_view_version += 1;

--- a/crates/viewport/src/pipeline.rs
+++ b/crates/viewport/src/pipeline.rs
@@ -100,6 +100,10 @@ pub struct SceneGraph {
     update_state_out: OutputPortUntyped,
 }
 
+/// Node to allow caching of the last node.
+///
+/// This node allows the last node of the [`ViewportPipeline`] to be cached, since otherwise
+/// the output of that node would be consumed with `compute()`.
 #[derive(PartialEq, Debug, Clone)]
 struct CloneSceneGraphNode();
 
@@ -135,6 +139,10 @@ pub struct ViewportPipeline {
     nodes: Vec<ViewportPluginNode>,
 }
 
+/// Project aware cache for the Viewport.
+///
+/// This is a extension of [`ComputationCache`], that allows changes to [`ProjectView`]s, if
+/// a node did only access parts of that, that did not change.
 #[derive(Default, Debug)]
 pub struct ViewportCache {
     prev_project_view: Option<Arc<ProjectView>>,

--- a/crates/viewport/src/pipeline.rs
+++ b/crates/viewport/src/pipeline.rs
@@ -567,12 +567,9 @@ impl ViewportPipeline {
     /// This should never happen under normal circumstances as the node was previously added to the graph.
     pub fn remove_last_plugin(&mut self) {
         if let Some(node) = self.nodes.pop() {
-            match self.graph.remove_node(node.node) {
-                Ok(()) => {}
-                Err(computegraph::RemoveNodeError::NodeNotFound(_)) => {
-                    panic!("We added it, so it should exist")
-                }
-            }
+            self.graph
+                .remove_node(node.node)
+                .expect("We added it, so it should exist");
         }
     }
 

--- a/crates/viewport/src/pipeline.rs
+++ b/crates/viewport/src/pipeline.rs
@@ -471,6 +471,7 @@ impl ViewportPipeline {
     pub fn compute_scene(
         &self,
         project_view: Arc<ProjectView>,
+        _project_view_version: u64,
     ) -> Result<SceneGraph, ExecuteError> {
         // TODO: pass ProjectView to ViewportPluginNodes
         let last_node = self.nodes.last().ok_or(ExecuteError::EmptyPipeline)?;
@@ -493,8 +494,9 @@ impl ViewportPipeline {
         state: &mut ViewportPipelineState,
         events: ViewportEvent,
         project_view: Arc<ProjectView>,
+        project_view_version: u64,
     ) -> Result<(), ExecuteError> {
-        let scene = self.compute_scene(project_view.clone())?;
+        let scene = self.compute_scene(project_view.clone(), project_view_version)?;
 
         let s = state.state.take();
         let s = match s {
@@ -526,8 +528,9 @@ impl ViewportPipeline {
         &self,
         state: &mut ViewportPipelineState,
         project_view: Arc<ProjectView>,
+        project_view_version: u64,
     ) -> Result<Box<dyn iced::widget::shader::Primitive>, ExecuteError> {
-        let scene = self.compute_scene(project_view.clone())?;
+        let scene = self.compute_scene(project_view.clone(), project_view_version)?;
 
         let s = state.state.take();
         let s = match s {

--- a/crates/viewport/src/pipeline.rs
+++ b/crates/viewport/src/pipeline.rs
@@ -529,7 +529,6 @@ impl ViewportPipeline {
         // TODO: pass ProjectView to ViewportPluginNodes
         let last_node = self.nodes.last().ok_or(ExecuteError::EmptyPipeline)?;
         let mut ctx = ComputationContext::default();
-        ctx.set_fallback(project_view.as_ref().clone());
         ctx.set_fallback_generator(move |_node_name| {
             let (view, _observer) = TrackedProjectView::new(project_view.clone());
             ProjectState::new(view, project_view_version)
@@ -567,7 +566,6 @@ impl ViewportPipeline {
         let mut ctx = ComputationContext::default();
         ctx.set_override_untyped(scene.update_state_in.clone(), s);
         ctx.set_override(scene.update_event_in, events);
-        ctx.set_fallback(project_view.as_ref().clone());
         ctx.set_fallback_generator(move |_node_name| {
             let (view, _observer) = TrackedProjectView::new(project_view.clone());
             ProjectState::new(view, project_view_version)
@@ -607,7 +605,6 @@ impl ViewportPipeline {
 
         let mut ctx = ComputationContext::default();
         ctx.set_override_untyped(scene.render_state_in.clone(), s);
-        ctx.set_fallback(project_view.as_ref().clone());
         ctx.set_fallback_generator(move |_node_name| {
             let (view, _observer) = TrackedProjectView::new(project_view.clone());
             ProjectState::new(view, project_view_version)

--- a/crates/viewport/tests/pipeline/basic_operations.rs
+++ b/crates/viewport/tests/pipeline/basic_operations.rs
@@ -86,10 +86,13 @@ fn test_compute_single_node_pipeline() {
 fn test_compute_empty_pipeline() {
     let pipeline = ViewportPipeline::default();
     let project = project::Project::new();
-    let result = pipeline.compute_scene(Arc::new(
-        project
-            .create_view(&project::ModuleRegistry::default())
-            .unwrap(),
-    ));
+    let result = pipeline.compute_scene(
+        Arc::new(
+            project
+                .create_view(&project::ModuleRegistry::default())
+                .unwrap(),
+        ),
+        1,
+    );
     assert!(matches!(result, Err(ExecuteError::EmptyPipeline)));
 }

--- a/crates/viewport/tests/pipeline/basic_operations.rs
+++ b/crates/viewport/tests/pipeline/basic_operations.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use crate::common::*;
 use viewport::{ExecuteError, ViewportPipeline, ViewportPlugin};
 
@@ -84,10 +86,10 @@ fn test_compute_single_node_pipeline() {
 fn test_compute_empty_pipeline() {
     let pipeline = ViewportPipeline::default();
     let project = project::Project::new();
-    let result = pipeline.compute_scene(
+    let result = pipeline.compute_scene(Arc::new(
         project
             .create_view(&project::ModuleRegistry::default())
             .unwrap(),
-    );
+    ));
     assert!(matches!(result, Err(ExecuteError::EmptyPipeline)));
 }

--- a/crates/viewport/tests/pipeline/basic_operations.rs
+++ b/crates/viewport/tests/pipeline/basic_operations.rs
@@ -93,6 +93,7 @@ fn test_compute_empty_pipeline() {
                 .unwrap(),
         ),
         1,
+        None,
     );
     assert!(matches!(result, Err(ExecuteError::EmptyPipeline)));
 }

--- a/crates/viewport/tests/pipeline/basic_operations.rs
+++ b/crates/viewport/tests/pipeline/basic_operations.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use crate::common::*;
-use viewport::{ExecuteError, ViewportPipeline, ViewportPlugin};
+use viewport::{ExecuteError, ViewportPipeline, ViewportPipelineCache, ViewportPlugin};
 
 #[test]
 fn test_viewport_plugins() {
@@ -93,7 +93,7 @@ fn test_compute_empty_pipeline() {
                 .unwrap(),
         ),
         1,
-        None,
+        &mut ViewportPipelineCache::default(),
     );
     assert!(matches!(result, Err(ExecuteError::EmptyPipeline)));
 }

--- a/crates/viewport/tests/pipeline/basic_operations.rs
+++ b/crates/viewport/tests/pipeline/basic_operations.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use crate::common::*;
-use viewport::{ExecuteError, ViewportPipeline, ViewportPipelineCache, ViewportPlugin};
+use viewport::{ExecuteError, ViewportCache, ViewportPipeline, ViewportPlugin};
 
 #[test]
 fn test_viewport_plugins() {
@@ -93,7 +93,7 @@ fn test_compute_empty_pipeline() {
                 .unwrap(),
         ),
         1,
-        &mut ViewportPipelineCache::default(),
+        &mut ViewportCache::default(),
     );
     assert!(matches!(result, Err(ExecuteError::EmptyPipeline)));
 }

--- a/crates/viewport/tests/pipeline/common.rs
+++ b/crates/viewport/tests/pipeline/common.rs
@@ -129,6 +129,7 @@ pub fn node_count(pipeline: &ViewportPipeline) -> Result<usize, Box<dyn std::err
         .compute_scene(
             Arc::new(p.create_view(&project::ModuleRegistry::default()).unwrap()),
             1,
+            None,
         )?
         .graph;
     let out_port = computegraph::OutputPortUntyped {

--- a/crates/viewport/tests/pipeline/common.rs
+++ b/crates/viewport/tests/pipeline/common.rs
@@ -126,9 +126,10 @@ fn run(&self, scene: &SceneGraph, input: &CounterState) -> (SceneGraph, CounterS
 pub fn node_count(pipeline: &ViewportPipeline) -> Result<usize, Box<dyn std::error::Error>> {
     let p = project::Project::new();
     let g = pipeline
-        .compute_scene(Arc::new(
-            p.create_view(&project::ModuleRegistry::default()).unwrap(),
-        ))?
+        .compute_scene(
+            Arc::new(p.create_view(&project::ModuleRegistry::default()).unwrap()),
+            1,
+        )?
         .graph;
     let out_port = computegraph::OutputPortUntyped {
         node: computegraph::NodeHandle {

--- a/crates/viewport/tests/pipeline/common.rs
+++ b/crates/viewport/tests/pipeline/common.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use computegraph::{node, ComputeGraph};
 use iced::widget::shader::{wgpu, Primitive};
 use viewport::{
@@ -124,7 +126,9 @@ fn run(&self, scene: &SceneGraph, input: &CounterState) -> (SceneGraph, CounterS
 pub fn node_count(pipeline: &ViewportPipeline) -> Result<usize, Box<dyn std::error::Error>> {
     let p = project::Project::new();
     let g = pipeline
-        .compute_scene(p.create_view(&project::ModuleRegistry::default()).unwrap())?
+        .compute_scene(Arc::new(
+            p.create_view(&project::ModuleRegistry::default()).unwrap(),
+        ))?
         .graph;
     let out_port = computegraph::OutputPortUntyped {
         node: computegraph::NodeHandle {

--- a/crates/viewport/tests/pipeline/common.rs
+++ b/crates/viewport/tests/pipeline/common.rs
@@ -4,7 +4,7 @@ use computegraph::{node, ComputeGraph};
 use iced::widget::shader::{wgpu, Primitive};
 use viewport::{
     RenderNodePorts, SceneGraph, SceneGraphBuilder, UpdateNodePorts, ViewportEvent,
-    ViewportPipeline,
+    ViewportPipeline, ViewportPipelineCache,
 };
 
 #[derive(Clone, PartialEq)]
@@ -129,7 +129,7 @@ pub fn node_count(pipeline: &ViewportPipeline) -> Result<usize, Box<dyn std::err
         .compute_scene(
             Arc::new(p.create_view(&project::ModuleRegistry::default()).unwrap()),
             1,
-            None,
+            &mut ViewportPipelineCache::default(),
         )?
         .graph;
     let out_port = computegraph::OutputPortUntyped {

--- a/crates/viewport/tests/pipeline/common.rs
+++ b/crates/viewport/tests/pipeline/common.rs
@@ -3,8 +3,8 @@ use std::sync::Arc;
 use computegraph::{node, ComputeGraph};
 use iced::widget::shader::{wgpu, Primitive};
 use viewport::{
-    RenderNodePorts, SceneGraph, SceneGraphBuilder, UpdateNodePorts, ViewportEvent,
-    ViewportPipeline, ViewportPipelineCache,
+    RenderNodePorts, SceneGraph, SceneGraphBuilder, UpdateNodePorts, ViewportCache, ViewportEvent,
+    ViewportPipeline,
 };
 
 #[derive(Clone, PartialEq)]
@@ -129,7 +129,7 @@ pub fn node_count(pipeline: &ViewportPipeline) -> Result<usize, Box<dyn std::err
         .compute_scene(
             Arc::new(p.create_view(&project::ModuleRegistry::default()).unwrap()),
             1,
-            &mut ViewportPipelineCache::default(),
+            &mut ViewportCache::default(),
         )?
         .graph;
     let out_port = computegraph::OutputPortUntyped {


### PR DESCRIPTION
This PR adds a efficient caching system for the `Viewport` widget.
Only the minimal set of nodes is now rerun on changes to the passed in `ProjectView`, considerably speeding up the viewport.
Caching is applied to both the `ViewportPlugins`, and the `SceneGraph`.

To test it, the `cadara` binary now shows a slowly growing cube.

While there are still some issues left to solve (#100 and #104), this implementation should be enough for the time being.