### PR TITLE
fix(wasm-libc,occara): define `__sF` so wasm tests link

### DIFF
--- a/crates/occara/tests/thread_safety.rs
+++ b/crates/occara/tests/thread_safety.rs
@@ -7,6 +7,7 @@ use occara::{
 
 #[test]
 fn test_thread_safety() {
+    wasm_libc::init();
     // This is a basic test for verifying that this library is probably thread safe.
     // Since all wrapper types function roughly in the same way, we will only test `Mesh` here.
     // This test passes while using valgrind.

--- a/crates/wasm-libc/src/lib.rs
+++ b/crates/wasm-libc/src/lib.rs
@@ -464,6 +464,11 @@ mod api {
     }
     static mut ERRNO: i32 = 0;
 
+    // Bundled libc omits the `__sF` array that `stdin`/`stdout`/`stderr` resolve to.
+    // The stdio stubs ignore the stream pointer, so room for three `FILE` entries suffices.
+    #[no_mangle]
+    pub static mut __sF: [u64; 48] = [0; 48];
+
     #[no_mangle]
     pub unsafe extern "C" fn abort() {
         error!("abort called");


### PR DESCRIPTION
`libc++abi`/`libstdc++` reference the BSD stdio `__sF` array (backing `stderr` etc.), but nothing defines it: not the bundled libc, not wasm-libc. So `rust-lld` fails to link the occara wasm tests. This adds a `__sF` stub in wasm-libc. The stdio stubs ignore the stream pointer, so a zeroed symbol with room for three `FILE` entries suffices.

`thread_safety` also never referenced wasm-libc, so rustc left its rlib out of the link and malloc/free/abort/`__cxa_*` went unresolved. It now calls `wasm_libc::init()` like the sibling tests, which also runs the required C++ global constructors.

Verified locally with `cargo make test-wasm`: meshing and make_bottle pass, all wasm test binaries link.