### PR TITLE
build: bump glam to 0.33

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1570,9 +1570,9 @@ checksum = "151665d9be52f9bb40fc7966565d39666f2d1e69233571b71b87791c7e0528b3"
 
 [[package]]
 name = "glam"
-version = "0.30.8"
+version = "0.33.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e12d847aeb25f41be4c0ec9587d624e9cd631bc007a8fd7ce3f5851e064c6460"
+checksum = "898f5a568a84989b6c0f8caa50a93074b97dbdc58fc6d9543157bb4562758933"
 dependencies = [
  "bytemuck",
 ]
@@ -2284,7 +2284,7 @@ version = "0.1.0"
 dependencies = [
  "bytemuck",
  "computegraph",
- "glam 0.30.8",
+ "glam 0.33.1",
  "iced",
  "modeling-module",
  "occara",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ dyn-clone = "1.0"
 uuid = { version = "1.16", features = ["v4", "serde", "js"] }
 serde = { version = "1.0", features = ["derive", "alloc", "rc"] }
 bytemuck = "1.22"
-glam = { version = "0.30", features = ["bytemuck"] }
+glam = { version = "0.33", features = ["bytemuck"] }
 walkdir = "2.4"
 paste = "1.0"
 


### PR DESCRIPTION
Bump glam 0.30 to 0.33. No source changes required; builds clean (native + wasm).