### PR TITLE
build: drop unused autocxx workspace dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,8 +44,6 @@ paste = "1.0"
 cxx = "1.0"
 cxx-build = { version = "1.0", features = ["parallel"] }
 cmake = "0.1"
-autocxx = "0.27"
-autocxx-build = "0.27"
 
 miette = { version = "7", features = ["fancy"] }
 criterion = { version = "0.7", features = ["html_reports"] }

--- a/deny.toml
+++ b/deny.toml
@@ -10,7 +10,6 @@ ignore = [
   #{ id = "RUSTSEC-0000-0000", reason = "you can specify a reason the advisory is ignored" },
   #"a-crate-that-is-yanked@0.1.1", # you can also ignore yanked crate versions if you wish
   #{ crate = "a-crate-that-is-yanked@0.1.1", reason = "you can specify why you are ignoring the yanked crate" },
-  { id = "RUSTSEC-2021-0145", reason = "this only impacts logging in 'autocxx-build', a build dependency and therefore has no risk" },
 ]
 
 [licenses]


### PR DESCRIPTION
Removes the leftover `autocxx`/`autocxx-build` workspace dependency declarations and the RUSTSEC-2021-0145 ignore that only existed for `autocxx-build`. The autocxx → cxx migration is already complete in `occara`; neither crate is referenced anymore (absent from `Cargo.lock`), and `cargo-deny` stays green since nothing pulls `atty`.