### PR TITLE
ci: warm lint workflow caches across PRs

### DIFF
--- a/.github/workflows/lint-docs.yml
+++ b/.github/workflows/lint-docs.yml
@@ -1,6 +1,8 @@
 name: Lint Rust Documentation
 
 on:
+  push:
+    branches: [main]
   pull_request:
 
 env:
@@ -30,12 +32,16 @@ jobs:
             target/*
             !target/opencascade-sys
           key: cargo-docs-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            cargo-docs-
       - name: Load OpenCASCADE Cache
         uses: actions/cache/restore@v4
         with:
           path: |
             target/opencascade-sys/
           key: occt-${{ runner.os }}-${{ hashFiles('crates/opencascade-sys/**') }}
+          restore-keys: |
+            occt-${{ runner.os }}-
       - name: Check documentation
         env:
           RUSTDOCFLAGS: -D warnings

--- a/.github/workflows/lint-rust.yml
+++ b/.github/workflows/lint-rust.yml
@@ -6,6 +6,8 @@ permissions:
   checks: write
 
 on:
+  push:
+    branches: [main]
   pull_request:
 
 env:
@@ -33,7 +35,6 @@ jobs:
   lint:
     name: Run Clippy
     runs-on: ubuntu-latest
-    if: ${{ github.event_name == 'pull_request' }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5
@@ -52,18 +53,26 @@ jobs:
             target/*
             !target/opencascade-sys
           key: cargo-clippy-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            cargo-clippy-
       - name: Load OpenCASCADE Cache
         uses: actions/cache/restore@v4
         with:
           path: |
             target/opencascade-sys/
           key: occt-${{ runner.os }}-${{ hashFiles('crates/opencascade-sys/**') }}
+          restore-keys: |
+            occt-${{ runner.os }}-
       - name: Run clippy
+        if: ${{ github.event_name == 'pull_request' }}
         uses: giraffate/clippy-action@v1
         with:
           reporter: "github-pr-review"
           clippy_flags: "--workspace --tests --benches"
           github_token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Warm clippy cache
+        if: ${{ github.event_name == 'push' }}
+        run: cargo clippy --workspace --tests --benches
 
   typos-cli:
     name: Check for typos


### PR DESCRIPTION
Mirrors the test-workflow cache fix for `lint-rust` and `lint-docs`: runs them on push to main so their cargo caches populate under the base-branch scope PRs can read, plus `restore-keys` fallbacks. The clippy job's PR-review reporter can't run on main, so it gains a push-only cache-warming build.