### PR TITLE
build: fix devcontainer build by replacing broken llvm feature with apt clang

### DIFF
--- a/.devcontainer/devcontainer-lock.json
+++ b/.devcontainer/devcontainer-lock.json
@@ -1,0 +1,9 @@
+{
+  "features": {
+    "ghcr.io/devcontainers/features/node:1": {
+      "version": "1.7.1",
+      "resolved": "ghcr.io/devcontainers/features/node@sha256:8c0de46939b61958041700ee89e3493f3b2e4131a06dc46b4d9423427d06e5f6",
+      "integrity": "sha256:8c0de46939b61958041700ee89e3493f3b2e4131a06dc46b4d9423427d06e5f6"
+    }
+  }
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,9 +2,7 @@
   "name": "Rust WASM Development",
   "image": "rust:latest",
   "features": {
-    "ghcr.io/devcontainers/features/node:1": {},
-    "ghcr.io/devcontainers/features/rust:1": {},
-    "ghcr.io/devcontainers-community/features/llvm:3": {}
+    "ghcr.io/devcontainers/features/node:1": {}
   },
   "postCreateCommand": "bash .devcontainer/setup.sh",
   "forwardPorts": [

--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
-apt update
-apt install -y cmake ninja-build
+apt-get update
+apt-get install -y cmake ninja-build clang lld llvm
 rustup install nightly # Required for wasm/c interop
 rustup +nightly target add wasm32-unknown-unknown
 


### PR DESCRIPTION
The `llvm` community feature fails to install on the trixie-based `rust:latest` image (apt.llvm.org has no trixie repo, so `software-properties-common` won't resolve), aborting the container build before `postCreate`/`setup.sh` ever run. This installs `clang`/`lld`/`llvm` via apt in `setup.sh` instead, and drops the redundant `rust` feature since the base image already ships rust.

Verified end to end with the `devcontainer` CLI: container builds (`outcome: success`), postCreate downloads the wasm libcxx and runs `setup-wasm`, and `cargo make build-wasm-dev` compiles the full workspace (incl. occara/OpenCASCADE) to wasm. The `node` feature is pinned via the committed `devcontainer-lock.json`.