### PR TITLE
fix(viewport): resolve cache metadata memory leak

### DIFF
--- a/crates/computegraph/src/lib.rs
+++ b/crates/computegraph/src/lib.rs
@@ -810,6 +810,18 @@ impl ComputationCache {
     pub fn new() -> Self {
         Self::default()
     }
+
+    /// Number of nodes holding a cached output.
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.node.len()
+    }
+
+    /// Returns `true` if no node output is cached.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.node.is_empty()
+    }
 }
 
 /// Options to customize [`ComputeGraph::compute_with`].

--- a/crates/viewport/src/lib.rs
+++ b/crates/viewport/src/lib.rs
@@ -82,8 +82,8 @@ pub trait ErasedPrimitive: std::fmt::Debug + Send + Sync + 'static {
 #[doc(inline)]
 pub use pipeline::{
     DynamicViewportPlugin, ExecuteError, PipelineAddError, ProjectState, RenderNodePorts,
-    SceneGraph, SceneGraphBuilder, UpdateNodePorts, ViewportCache, ViewportPipeline,
-    ViewportPlugin, ViewportPluginValidationError,
+    SceneGraph, SceneGraphBuilder, UpdateNodePorts, ViewportCache, ViewportCacheStats,
+    ViewportPipeline, ViewportPlugin, ViewportPluginValidationError,
 };
 
 #[derive(Debug)]

--- a/crates/viewport/src/pipeline.rs
+++ b/crates/viewport/src/pipeline.rs
@@ -151,6 +151,15 @@ pub struct ViewportCache {
     metadata: Option<CacheMetadata>,
 }
 
+/// Occupancy snapshot of a [`ViewportCache`], for debug and introspection UIs.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ViewportCacheStats {
+    /// Nodes holding a memoized output in the computation cache.
+    pub computation_entries: usize,
+    /// Nodes carrying project-aware cache metadata.
+    pub metadata_nodes: Vec<String>,
+}
+
 impl ViewportCache {
     /// Drops the computation cache and metadata.
     ///
@@ -160,6 +169,19 @@ impl ViewportCache {
     fn clear(&mut self) {
         *self.cache.lock().unwrap() = ComputationCache::default();
         self.metadata = None;
+    }
+
+    /// Returns the current cache occupancy.
+    #[must_use]
+    #[expect(clippy::missing_panics_doc, reason = "only panics with poisoned lock")]
+    pub fn stats(&self) -> ViewportCacheStats {
+        ViewportCacheStats {
+            computation_entries: self.cache.lock().unwrap().len(),
+            metadata_nodes: self
+                .metadata
+                .as_ref()
+                .map_or_else(Vec::new, |m| m.keys().cloned().collect()),
+        }
     }
 }
 

--- a/crates/viewport/src/pipeline.rs
+++ b/crates/viewport/src/pipeline.rs
@@ -6,7 +6,7 @@ use computegraph::{
 use project::{CacheValidator, ProjectView, TrackedProjectView};
 use std::{
     any::TypeId,
-    collections::BTreeMap,
+    collections::{BTreeMap, HashSet},
     sync::{Arc, Mutex},
 };
 
@@ -149,6 +149,18 @@ pub struct ViewportCache {
     cache: Mutex<ComputationCache>,
     version: u64,
     metadata: Option<CacheMetadata>,
+}
+
+impl ViewportCache {
+    /// Drops the computation cache and metadata.
+    ///
+    /// `compute_with` only prunes cache entries for absent nodes while computing,
+    /// so an empty pipeline (which never computes) would otherwise retain both maps
+    /// from its last non-empty state indefinitely.
+    fn clear(&mut self) {
+        *self.cache.lock().unwrap() = ComputationCache::default();
+        self.metadata = None;
+    }
 }
 
 #[derive(Default, Debug)]
@@ -380,13 +392,27 @@ fn initialize_access_tracking(
     access_recorders
 }
 
-fn update_cache_metadata(metadata: &mut CacheMetadata, access_recorders: &AccessRecorders) {
+fn update_cache_metadata(
+    metadata: &mut CacheMetadata,
+    access_recorders: &AccessRecorders,
+    active_node_names: Option<&HashSet<String>>,
+) {
     let access_recorders = std::mem::take(&mut *(access_recorders.lock().unwrap()));
     // Freeze and collect all access recorder data.
     let mut access_data: BTreeMap<_, _> = access_recorders
         .into_iter()
         .map(|(node_name, (recorder, version))| (node_name, (recorder.freeze(), version)))
         .collect();
+
+    // Drop metadata for nodes no longer in the graph.
+    if let Some(active_nodes) = active_node_names {
+        // Pipeline nodes: explicit list, independent of ProjectState usage.
+        metadata.retain(|node_name, _| active_nodes.contains(node_name));
+    } else {
+        // Scene graph nodes: access_data holds every node tracked this computation,
+        // so anything missing was removed. Metadata only ever holds tracked nodes.
+        metadata.retain(|node_name, _| access_data.contains_key(node_name));
+    }
 
     // Update metadata for nodes that already existed.
     for (node_name, (existing_validator, existing_version)) in metadata.iter_mut() {
@@ -640,6 +666,12 @@ impl ViewportPipeline {
         project_view_version: u64,
         cache: &mut ViewportCache,
     ) -> Result<SceneGraph, ExecuteError> {
+        // Empty pipeline never computes, so prune the stale cache eagerly.
+        if self.is_empty() {
+            cache.clear();
+            return Err(ExecuteError::EmptyPipeline);
+        }
+
         let mut cache_metadata = cache.metadata.take().unwrap_or_default();
         if let Some(prev_project_view) = &cache.prev_project_view {
             if cache.version != project_view_version {
@@ -678,7 +710,21 @@ impl ViewportPipeline {
         let mut cache_metadata =
             Arc::try_unwrap(cache_metadata).expect("we dropped ctx, which had the only other copy");
 
-        update_cache_metadata(&mut cache_metadata, &access_recorders);
+        // Collect active node names from the pipeline (both main nodes and cache nodes)
+        let active_node_names: HashSet<String> = self
+            .nodes
+            .iter()
+            .flat_map(|n| {
+                let cache_name = format!("{}_cache", n.node.node_name);
+                vec![n.node.node_name.clone(), cache_name]
+            })
+            .collect();
+
+        update_cache_metadata(
+            &mut cache_metadata,
+            &access_recorders,
+            Some(&active_node_names),
+        );
 
         cache.metadata = Some(cache_metadata);
 
@@ -746,7 +792,7 @@ impl ViewportPipeline {
         let mut cache_metadata =
             Arc::try_unwrap(cache_metadata).expect("we dropped ctx, which had the only other copy");
 
-        update_cache_metadata(&mut cache_metadata, &access_recorders);
+        update_cache_metadata(&mut cache_metadata, &access_recorders, None);
 
         state.scenegraph_cache.metadata = Some(cache_metadata);
 
@@ -817,7 +863,7 @@ impl ViewportPipeline {
         let mut cache_metadata =
             Arc::try_unwrap(cache_metadata).expect("we dropped ctx, which had the only other copy");
 
-        update_cache_metadata(&mut cache_metadata, &access_recorders);
+        update_cache_metadata(&mut cache_metadata, &access_recorders, None);
 
         state.scenegraph_cache.metadata = Some(cache_metadata);
 

--- a/crates/viewport/tests/pipeline/cache_leak.rs
+++ b/crates/viewport/tests/pipeline/cache_leak.rs
@@ -1,0 +1,67 @@
+use std::sync::Arc;
+
+use viewport::{ExecuteError, ViewportCache, ViewportPipeline, ViewportPlugin};
+
+use crate::common::ProjectAwarePlugin;
+
+fn empty_view() -> Arc<project::ProjectView> {
+    let project = project::Project::new();
+    Arc::new(
+        project
+            .create_view(&project::ModuleRegistry::default())
+            .unwrap(),
+    )
+}
+
+/// Removing a plugin while the pipeline stays non-empty evicts the dead node's
+/// metadata instead of accumulating it on top of the survivor's.
+#[test]
+fn evicts_removed_node_while_nonempty() {
+    let mut pipeline = ViewportPipeline::default();
+    let mut cache = ViewportCache::default();
+    let view = empty_view();
+
+    pipeline
+        .add_plugin(ViewportPlugin::new(ProjectAwarePlugin).unwrap())
+        .unwrap();
+    pipeline
+        .add_plugin(ViewportPlugin::new(ProjectAwarePlugin).unwrap())
+        .unwrap();
+
+    // Only the last plugin's node executes, so exactly one node is tracked.
+    pipeline.compute_scene(view.clone(), 1, &mut cache).unwrap();
+    assert_eq!(cache.stats().metadata_nodes.len(), 1);
+
+    // A leak would add the new last node without dropping the removed one,
+    // pushing the count to 2.
+    pipeline.remove_last_plugin();
+    pipeline.compute_scene(view, 2, &mut cache).unwrap();
+    assert_eq!(cache.stats().metadata_nodes.len(), 1);
+}
+
+/// Emptying the pipeline drops both caches rather than retaining the last
+/// non-empty state forever.
+#[test]
+fn clears_caches_when_pipeline_empty() {
+    let mut pipeline = ViewportPipeline::default();
+    let mut cache = ViewportCache::default();
+    let view = empty_view();
+
+    pipeline
+        .add_plugin(ViewportPlugin::new(ProjectAwarePlugin).unwrap())
+        .unwrap();
+    pipeline.compute_scene(view.clone(), 1, &mut cache).unwrap();
+    let stats = cache.stats();
+    assert!(!stats.metadata_nodes.is_empty());
+    assert!(stats.computation_entries > 0);
+
+    pipeline.remove_last_plugin();
+    assert!(matches!(
+        pipeline.compute_scene(view, 2, &mut cache),
+        Err(ExecuteError::EmptyPipeline)
+    ));
+
+    let stats = cache.stats();
+    assert!(stats.metadata_nodes.is_empty());
+    assert_eq!(stats.computation_entries, 0);
+}

--- a/crates/viewport/tests/pipeline/common.rs
+++ b/crates/viewport/tests/pipeline/common.rs
@@ -4,7 +4,7 @@ use computegraph::{node, ComputeGraph};
 use iced::wgpu;
 use iced::widget::shader;
 use viewport::{
-    ErasedPrimitive, RenderNodePorts, SceneGraph, SceneGraphBuilder, UpdateNodePorts,
+    ErasedPrimitive, ProjectState, RenderNodePorts, SceneGraph, SceneGraphBuilder, UpdateNodePorts,
     ViewportCache, ViewportEvent, ViewportPipeline,
 };
 
@@ -54,6 +54,36 @@ pub struct UpdateNode();
 #[node(UpdateNode)]
 fn run(&self, state: &State, _event: &ViewportEvent) -> State {
     (*state).clone()
+}
+
+/// A plugin that consumes a [`ProjectState`], so its pipeline node shows up in
+/// the cache metadata.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ProjectAwarePlugin;
+
+#[node(ProjectAwarePlugin -> (scene, output))]
+fn run(&self, _project: &ProjectState) -> (SceneGraph, usize) {
+    let mut graph = ComputeGraph::default();
+    let init_state_node = graph.add_node(InitState(), "init".to_string()).unwrap();
+    let render_node = graph.add_node(RenderNode(), "render".to_string()).unwrap();
+    let update_node = graph.add_node(UpdateNode(), "update".to_string()).unwrap();
+    (
+        SceneGraphBuilder {
+            graph,
+            initial_state: init_state_node.output(),
+            render_node: RenderNodePorts {
+                state_in: render_node.input_state(),
+                primitive_out: render_node.output(),
+            },
+            update_node: UpdateNodePorts {
+                state_in: update_node.input_state(),
+                event_in: update_node.input_event(),
+                state_out: update_node.output(),
+            },
+        }
+        .into(),
+        1,
+    )
 }
 
 #[derive(Debug, Clone, PartialEq)]

--- a/crates/viewport/tests/pipeline/main.rs
+++ b/crates/viewport/tests/pipeline/main.rs
@@ -1,4 +1,5 @@
 mod basic_operations;
+mod cache_leak;
 mod common;
 mod dynamic_nodes;
 mod error_handling;


### PR DESCRIPTION
Cache metadata for removed viewport nodes was kept indefinitely, so repeatedly adding and removing plugins leaked memory. `update_cache_metadata` now retains only the nodes still in the pipeline, and both caches are dropped once the pipeline is empty.

Also adds `ComputationCache::len`/`is_empty` and `ViewportCache::stats`, so a  furutre debug UI (and the new tests) can read cache size and contents.

Closes #104