### PR TITLE
feat(project): add CRDT op log with multi-replica merge and undo/redo

### DIFF
--- a/crates/project/src/branch.rs
+++ b/crates/project/src/branch.rs
@@ -18,7 +18,6 @@ pub struct BranchId(Uuid);
 impl BranchId {
     /// Creates a new random branch identifier.
     #[must_use]
-    #[expect(dead_code)]
     pub fn new() -> Self {
         Self(Uuid::new_v4())
     }

--- a/crates/project/src/checkpoint.rs
+++ b/crates/project/src/checkpoint.rs
@@ -1,18 +1,18 @@
 //! Project Checkpoints.
 //!
-//! Checkpoints are used to give a point in the log [`crate::Project::log`] a nameable identifier.
+//! Checkpoints are used to give a point in the project's log a nameable identifier.
 //!
 //! Uses for this include:
 //! - Associate a revision with a specific point in time.
 //! - Split a Design Task into multiple chronological steps.
 //!
 //! It must however be noted that generating a [`crate::ProjectView`] until a specific [`CheckpointId`]
-//! will NOT guarantee the same [`crate::ProjectView`] due to possible insertion of new [`crate::ProjectLogEntry`] before the
+//! will NOT guarantee the same [`crate::ProjectView`] due to possible insertion of new [`crate::LogEntry`] before the
 //! checkpoint when an offline user reconnects and uploads its changes.
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
-/// Unique identifier to a point in the [`crate::Project::log`].
+/// Unique identifier to a point in the project's log.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(transparent)]
 pub struct CheckpointId(Uuid);

--- a/crates/project/src/lib.rs
+++ b/crates/project/src/lib.rs
@@ -160,6 +160,7 @@ mod document;
 mod module_data;
 mod oplog;
 mod project;
+mod resolve;
 mod tracked;
 mod user;
 

--- a/crates/project/src/lib.rs
+++ b/crates/project/src/lib.rs
@@ -372,22 +372,6 @@ impl ChangeBuilder {
             Ok(())
         }
     }
-
-    /// Record an `Undo` for the current session. Resolved at `create_view`.
-    pub fn undo(&mut self) {
-        self.changes.push(PendingChange::Undo);
-    }
-
-    /// Record a `Redo` for the current session. Resolved at `create_view`.
-    pub fn redo(&mut self) {
-        self.changes.push(PendingChange::Redo);
-    }
-
-    /// Record a one-shot snapshot merge from `from` into `into`.
-    /// Undoable like any other session-scoped op.
-    pub fn merge_branch(&mut self, from: BranchId, into: BranchId) {
-        self.changes.push(PendingChange::MergeBranch { from, into });
-    }
 }
 
 /// Project in the `CADara` application.
@@ -717,7 +701,7 @@ impl Project {
                 PendingChange::Change(Change::UserTransaction { args, .. }) => Some(args.module),
                 PendingChange::SessionTransaction { args, .. } => Some(args.module),
                 PendingChange::SharedTransaction { args, .. } => Some(args.module),
-                _ => None,
+                PendingChange::Change(_) => None,
             };
             if let Some(module) = module {
                 if !reg.0.contains_key(&module) {
@@ -729,16 +713,9 @@ impl Project {
         let session = self.ensure_session();
 
         let mut grouped: Vec<Change> = Vec::new();
-        let mut tail_payloads: Vec<LogPayload> = Vec::new();
-
         for pc in cb.changes {
             match pc {
                 PendingChange::Change(c) => grouped.push(c),
-                PendingChange::Undo => tail_payloads.push(LogPayload::Undo),
-                PendingChange::Redo => tail_payloads.push(LogPayload::Redo),
-                PendingChange::MergeBranch { from, into } => {
-                    tail_payloads.push(LogPayload::MergeBranch { from, into });
-                }
                 PendingChange::SessionTransaction { id, args } => {
                     let entry = reg.0.get(&args.module).expect("already checked above");
                     let data = self
@@ -766,12 +743,39 @@ impl Project {
             let head = self.new_entry(session, LogPayload::Changes(grouped));
             self.log.push(head);
         }
-        for payload in tail_payloads {
-            let entry = self.new_entry(session, payload);
-            self.log.push(entry);
-        }
 
         Ok(())
+    }
+
+    /// Record an `Undo` for the current session.
+    ///
+    /// Cancels the most recent live `Changes` or `MergeBranch` entry emitted by
+    /// this session, per the spec's per-session undo/redo algorithm. Has no
+    /// effect on other sessions' entries.
+    pub fn undo(&mut self) {
+        let session = self.ensure_session();
+        let entry = self.new_entry(session, LogPayload::Undo);
+        self.log.push(entry);
+    }
+
+    /// Record a `Redo` for the current session.
+    ///
+    /// Restores the most recently undone entry by this session (LIFO from the
+    /// per-session redo buffer).
+    pub fn redo(&mut self) {
+        let session = self.ensure_session();
+        let entry = self.new_entry(session, LogPayload::Redo);
+        self.log.push(entry);
+    }
+
+    /// Record a snapshot-import merge of `from` into `into`.
+    ///
+    /// Undoable like any other session-scoped op. See the spec's visibility
+    /// rule for what becomes visible from `into` after this merge.
+    pub fn merge_branch(&mut self, from: BranchId, into: BranchId) {
+        let session = self.ensure_session();
+        let entry = self.new_entry(session, LogPayload::MergeBranch { from, into });
+        self.log.push(entry);
     }
 
     fn ensure_session(&mut self) -> SessionId {

--- a/crates/project/src/lib.rs
+++ b/crates/project/src/lib.rs
@@ -584,8 +584,6 @@ impl Project {
     /// # Errors
     /// Returns an error if:
     /// - A required module is not found in the registry
-    #[expect(clippy::too_many_lines)]
-    #[expect(clippy::cognitive_complexity)]
     pub fn create_view(&self, reg: &ModuleRegistry) -> Result<ProjectView, ProjectViewError> {
         let mut data = HashMap::new();
         let mut documents = HashMap::new();
@@ -595,102 +593,15 @@ impl Project {
             match log_entry {
                 ProjectLogEntry::Changes { session, changes } => {
                     for change in changes {
-                        match change {
-                            Change::CreateDocument { id, path: _ } => {
-                                documents.insert(*id, Document::default());
-                            }
-                            Change::DeleteDocument(document_id) => {
-                                if let Some((_, document)) = documents.remove_entry(document_id) {
-                                    for data_id in &document.data {
-                                        data.remove(data_id);
-                                    }
-                                }
-                            }
-                            Change::RenameDocument { id: _, new_name: _ }
-                            | Change::MoveDocument {
-                                id: _,
-                                new_folder: _,
-                            }
-                            | Change::MoveFolder {
-                                old_path: _,
-                                new_path: _,
-                            } => {
-                                // TODO: implement and test folder support, including views to traverse them
-                            }
-                            Change::CreateData { id, module, owner } => {
-                                data.insert(
-                                    *id,
-                                    (reg.0
-                                        .get(module)
-                                        .ok_or(ProjectViewError::UnknownModule(*module))?
-                                        .init_data)(),
-                                );
-                                if let Some(owner) = owner {
-                                    documents
-                                        .entry(*owner)
-                                        .or_insert_with(Default::default)
-                                        .data
-                                        .push(*id);
-                                }
-                            }
-                            Change::DeleteData(id) => {
-                                data.remove(id);
-                            }
-                            Change::MoveData { id, new_owner } => {
-                                for document in documents.values_mut() {
-                                    document.data.retain(|data_id| data_id != id);
-                                }
-                                if let Some(new_owner) = new_owner {
-                                    if let Some(doc) = documents.get_mut(new_owner) {
-                                        doc.data.push(*id);
-                                    } else {
-                                        error!("Can not move data to non existent document");
-                                    }
-                                }
-                            }
-                            Change::Transaction { id, args } => {
-                                let reg = reg
-                                    .0
-                                    .get(&args.module)
-                                    .ok_or(ProjectViewError::UnknownModule(args.module))?;
-                                match data.get_mut(id) {
-                                    Some(data) if data.module == args.module => {
-                                        if let Err(err) = (reg.apply_data_transaction)(data, args) {
-                                            error!("Failed to apply Transaction: {err}");
-                                        }
-                                    }
-                                    Some(_) => {
-                                        error!(
-                                            "Data and DataArgs of {id} do not have the same Module type"
-                                        );
-                                    }
-                                    None => {}
-                                }
-                            }
-                            Change::UserTransaction { id, args } => {
-                                if let Some(user) = sessions.get(session) {
-                                    if self.user == *user {
-                                        let reg = reg
-                                            .0
-                                            .get(&args.module)
-                                            .ok_or(ProjectViewError::UnknownModule(args.module))?;
-                                        match data.get_mut(id) {
-                                            Some(data) if data.module == args.module => {
-                                                if let Err(err) =
-                                                    (reg.apply_user_data_transaction)(data, args)
-                                                {
-                                                    error!("Failed to apply Transaction: {err}");
-                                                }
-                                            }
-                                            Some(_) => {
-                                                error!("UserData and UserDataArgs of {id} do not have the same Module type");
-                                            }
-                                            None => {}
-                                        }
-                                    }
-                                }
-                            }
-                        }
+                        apply_change(
+                            change,
+                            &mut data,
+                            &mut documents,
+                            &sessions,
+                            self.user,
+                            *session,
+                            reg,
+                        )?;
                     }
                 }
                 // TODO: implement and Test undo/redo
@@ -880,4 +791,107 @@ impl Project {
         self.log.push(ProjectLogEntry::Changes { session, changes });
         Ok(())
     }
+}
+
+/// Apply a single `Change` to the in-progress view state.
+///
+/// `data` and `documents` are the running per-id maps that `create_view`
+/// builds. `session_user_map` maps a `SessionId` to the `UserId` that
+/// owns it (populated from `NewSession` entries). `viewer` is the user
+/// the view is being constructed for; this gates `UserTransaction`.
+#[allow(clippy::too_many_arguments, reason = "all params are distinct view-building state; no natural grouping")]
+fn apply_change(
+    change: &Change,
+    data: &mut HashMap<DataId, module_data::ErasedData>,
+    documents: &mut HashMap<DocumentId, Document>,
+    session_user_map: &HashMap<SessionId, UserId>,
+    viewer: UserId,
+    issuing_session: SessionId,
+    reg: &ModuleRegistry,
+) -> Result<(), ProjectViewError> {
+    match change {
+        Change::CreateDocument { id, path: _ } => {
+            documents.insert(*id, Document::default());
+        }
+        Change::DeleteDocument(document_id) => {
+            if let Some((_, document)) = documents.remove_entry(document_id) {
+                for data_id in &document.data {
+                    data.remove(data_id);
+                }
+            }
+        }
+        Change::RenameDocument { .. }
+        | Change::MoveDocument { .. }
+        | Change::MoveFolder { .. } => {
+            // Pre-existing TODO: folder support. Intentionally no-op.
+        }
+        Change::CreateData { id, module, owner } => {
+            data.insert(
+                *id,
+                (reg.0
+                    .get(module)
+                    .ok_or(ProjectViewError::UnknownModule(*module))?
+                    .init_data)(),
+            );
+            if let Some(owner) = owner {
+                documents.entry(*owner).or_default().data.push(*id);
+            }
+        }
+        Change::DeleteData(id) => {
+            data.remove(id);
+        }
+        Change::MoveData { id, new_owner } => {
+            for document in documents.values_mut() {
+                document.data.retain(|data_id| data_id != id);
+            }
+            if let Some(new_owner) = new_owner {
+                if let Some(doc) = documents.get_mut(new_owner) {
+                    doc.data.push(*id);
+                } else {
+                    error!("Can not move data to non existent document");
+                }
+            }
+        }
+        Change::Transaction { id, args } => {
+            let entry = reg
+                .0
+                .get(&args.module)
+                .ok_or(ProjectViewError::UnknownModule(args.module))?;
+            match data.get_mut(id) {
+                Some(d) if d.module == args.module => {
+                    if let Err(err) = (entry.apply_data_transaction)(d, args) {
+                        error!("Failed to apply Transaction: {err}");
+                    }
+                }
+                Some(_) => {
+                    error!("Data and DataArgs of {id} do not have the same Module type");
+                }
+                None => {}
+            }
+        }
+        Change::UserTransaction { id, args } => {
+            if let Some(user) = session_user_map.get(&issuing_session) {
+                if viewer == *user {
+                    let entry = reg
+                        .0
+                        .get(&args.module)
+                        .ok_or(ProjectViewError::UnknownModule(args.module))?;
+                    match data.get_mut(id) {
+                        Some(d) if d.module == args.module => {
+                            if let Err(err) = (entry.apply_user_data_transaction)(d, args) {
+                                error!("Failed to apply Transaction: {err}");
+                            }
+                        }
+                        Some(_) => {
+                            error!(
+                                "UserData and UserDataArgs of {id} do not have the same Module type"
+                            );
+                        }
+                        None => {}
+                    }
+                }
+            }
+        }
+    }
+    Ok(())
 }

--- a/crates/project/src/lib.rs
+++ b/crates/project/src/lib.rs
@@ -507,6 +507,8 @@ pub struct Project {
     ///
     /// By default, this is `main`.
     branch: BranchId,
+    /// Lamport clock for ordering log entries.
+    lamport_clock: u64,
     /// Chronological list of entries required to rebuild the entire [`ProjectView`] excluding
     /// shared and session data
     log: Vec<ProjectLogEntry>,
@@ -528,6 +530,7 @@ impl Default for Project {
             user: UserId::default(),
             session: Option::default(),
             branch: BranchId::default(),
+            lamport_clock: 0,
             log: Vec::default(),
             shared_data: HashMap::default(),
             session_data: HashMap::default(),

--- a/crates/project/src/lib.rs
+++ b/crates/project/src/lib.rs
@@ -706,6 +706,11 @@ impl Project {
         // Technically the project could change in the meantime by other ChangeBuilders,
         // but due to multi-user support, we nevertheless need to support that.
 
+        // Nothing to record: skip session allocation and log writes entirely.
+        if cb.changes.is_empty() {
+            return Ok(());
+        }
+
         // Verify all module references first.
         for change in &cb.changes {
             let module = match change {

--- a/crates/project/src/lib.rs
+++ b/crates/project/src/lib.rs
@@ -481,9 +481,37 @@ impl Project {
         let mut documents = HashMap::new();
         let mut sessions: HashMap<SessionId, UserId> = HashMap::new();
 
-        for entry in &self.log {
+        // Sort by (lamport, session) — equivalent to insertion order today, but
+        // explicit so the function stays correct after merge_remote.
+        let mut ordered: Vec<&LogEntry> = self.log.iter().collect();
+        ordered.sort_by_key(|e| (e.lamport, e.session));
+
+        // First pass: register sessions so apply_change can resolve UserTransaction.
+        for entry in &ordered {
+            if let LogPayload::NewSession { user, .. } = entry.payload {
+                sessions.insert(entry.session, user);
+            }
+        }
+
+        // Second pass: per-session active set via the resolver.
+        let mut by_session: HashMap<SessionId, Vec<&LogEntry>> = HashMap::new();
+        for entry in &ordered {
+            by_session.entry(entry.session).or_default().push(entry);
+        }
+        let mut active_key: std::collections::HashSet<(u64, SessionId)> =
+            std::collections::HashSet::new();
+        for session_entries in by_session.values() {
+            for i in resolve::per_session_active_set(session_entries) {
+                let e = session_entries[i];
+                active_key.insert((e.lamport, e.session));
+            }
+        }
+
+        // Third pass: walk in global order, apply active Changes only.
+        for entry in &ordered {
+            let active = active_key.contains(&(entry.lamport, entry.session));
             match &entry.payload {
-                LogPayload::Changes(changes) => {
+                LogPayload::Changes(changes) if active => {
                     for change in changes {
                         apply_change(
                             change,
@@ -496,13 +524,15 @@ impl Project {
                         )?;
                     }
                 }
-                LogPayload::NewSession { user, .. } => {
-                    sessions.insert(entry.session, *user);
-                }
-                LogPayload::Checkpoint(_)
+                LogPayload::Changes(_)
                 | LogPayload::Undo
                 | LogPayload::Redo
-                | LogPayload::MergeBranch { .. } => {}
+                | LogPayload::NewSession { .. }
+                | LogPayload::Checkpoint(_)
+                | LogPayload::MergeBranch { .. } => {
+                    // Either inactive Changes (skipped), or no view-time effect.
+                    // MergeBranch becomes meaningful in Task 13.
+                }
             }
         }
 

--- a/crates/project/src/lib.rs
+++ b/crates/project/src/lib.rs
@@ -32,6 +32,26 @@
 //!   undo/redo.
 //! - **[`TrackedProjectView`]:** A tracked version of a [`ProjectView`] allowing implicit dependency tracking
 //!
+//! ## CRDT Architecture
+//!
+//! The project's log is structured in three layers:
+//!
+//! 1. **Convergent op log.** [`Project`] holds a [`Vec<LogEntry>`](LogEntry),
+//!    where each entry carries a totally-ordered `(lamport, session)` key.
+//!    Two replicas that have seen the same set of entries produce identical
+//!    state after sort, regardless of merge order. [`Project::merge_remote`]
+//!    is the convergence primitive.
+//! 2. **Resolved op stream.** A pure function of layer 1: walks each session's
+//!    entries in lamport order, applying its `Undo`/`Redo` entries to figure
+//!    out which of its `Changes` and `MergeBranch` entries are currently
+//!    "active", and filters by branch visibility. No public type; lives inside
+//!    [`Project::create_view_at`].
+//! 3. **Materialized view.** [`ProjectView`], built by replaying the resolved
+//!    stream through [`module::DataSection::apply`].
+//!
+//! Each layer is a pure function over the layer below; views are recomputed
+//! on demand and cached by callers (see [`TrackedProjectView`]).
+//!
 //! ## Usage
 //!
 //! 1. **Create a new `Project`:**

--- a/crates/project/src/lib.rs
+++ b/crates/project/src/lib.rs
@@ -467,41 +467,55 @@ pub enum ApplyError {
 }
 
 impl Project {
-    /// Creates a new [`ProjectView`] by replaying the project's change history.
+    /// Creates a [`ProjectView`] of the current branch at the latest point in time.
     ///
-    /// # Description
-    /// Reconstructs the current state of the project by applying all logged changes
-    /// in chronological order, creating a consistent view of:
-    /// - All documents and their metadata
-    /// - All persistent data associated with modules
-    /// - Current document structure and relationships
-    ///
-    /// # Arguments
-    /// * `reg` - The [`ModuleRegistry`] containing all module implementations that were
-    ///   ever used in the project
-    ///
-    /// # Returns
-    /// Returns a [`ProjectView`] representing the current state of the project.
+    /// Delegates to [`Project::create_view_at`] with default branch and no time cutoff.
     ///
     /// # Errors
-    /// Returns an error if:
-    /// - A required module is not found in the registry
+    /// Returns an error if a required module is not found in the registry.
     pub fn create_view(&self, reg: &ModuleRegistry) -> Result<ProjectView, ProjectViewError> {
+        self.create_view_at(reg, self.branch, u64::MAX)
+    }
+
+    /// Creates a [`ProjectView`] scoped to a branch and a Lamport-clock cutoff.
+    ///
+    /// Only log entries with `lamport <= as_of` are included. Branch filtering is a
+    /// no-op until Task 13 wires `compute_visible_branches`; the parameter is
+    /// accepted here to establish the API surface.
+    ///
+    /// # Errors
+    /// Returns an error if a required module is not found in the registry.
+    pub fn create_view_at(
+        &self,
+        reg: &ModuleRegistry,
+        branch: BranchId,
+        as_of: u64,
+    ) -> Result<ProjectView, ProjectViewError> {
         let mut data = HashMap::new();
         let mut documents = HashMap::new();
         let mut sessions: HashMap<SessionId, UserId> = HashMap::new();
+        let mut session_branch: HashMap<SessionId, BranchId> = HashMap::new();
 
         // Sort by (lamport, session) — equivalent to insertion order today, but
         // explicit so the function stays correct after merge_remote.
-        let mut ordered: Vec<&LogEntry> = self.log.iter().collect();
+        let mut ordered: Vec<&LogEntry> = self
+            .log
+            .iter()
+            .filter(|e| e.lamport <= as_of)
+            .collect();
         ordered.sort_by_key(|e| (e.lamport, e.session));
 
         // First pass: register sessions so apply_change can resolve UserTransaction.
         for entry in &ordered {
-            if let LogPayload::NewSession { user, .. } = entry.payload {
+            if let LogPayload::NewSession { user, branch: b } = entry.payload {
                 sessions.insert(entry.session, user);
+                session_branch.insert(entry.session, b);
             }
         }
+
+        // Branch filter is a no-op until Task 13.
+        let _ = branch;
+        let _ = &session_branch;
 
         // Second pass: per-session active set via the resolver.
         let mut by_session: HashMap<SessionId, Vec<&LogEntry>> = HashMap::new();
@@ -548,13 +562,12 @@ impl Project {
 
         for (id, session_data) in &self.session_data {
             match data.get_mut(id) {
-                Some(data) if data.module == session_data.module => {
-                    if let Err(err) =
-                        (reg.0
-                            .get(&session_data.module)
-                            .ok_or(ProjectViewError::UnknownModule(session_data.module))?
-                            .replace_session_data)(data, session_data)
-                    {
+                Some(d) if d.module == session_data.module => {
+                    let entry = reg
+                        .0
+                        .get(&session_data.module)
+                        .ok_or(ProjectViewError::UnknownModule(session_data.module))?;
+                    if let Err(err) = (entry.replace_session_data)(d, session_data) {
                         error!("Failed to replace Data::session with SessionData: {err}");
                     }
                 }
@@ -567,13 +580,12 @@ impl Project {
 
         for (id, shared_data) in &self.shared_data {
             match data.get_mut(id) {
-                Some(data) if data.module == shared_data.module => {
-                    if let Err(err) =
-                        (reg.0
-                            .get(&shared_data.module)
-                            .ok_or(ProjectViewError::UnknownModule(shared_data.module))?
-                            .replace_shared_data)(data, shared_data)
-                    {
+                Some(d) if d.module == shared_data.module => {
+                    let entry = reg
+                        .0
+                        .get(&shared_data.module)
+                        .ok_or(ProjectViewError::UnknownModule(shared_data.module))?;
+                    if let Err(err) = (entry.replace_shared_data)(d, shared_data) {
                         error!("Failed to replace Data::shared with SharedData: {err}");
                     }
                 }

--- a/crates/project/src/lib.rs
+++ b/crates/project/src/lib.rs
@@ -608,15 +608,21 @@ impl Project {
         Self::default()
     }
 
-    /// Fork a second in-memory replica that shares this project's uuid and
-    /// log snapshot, but starts with a fresh user and no session.
+    /// Fork a new replica from this project, suitable for editing on another
+    /// device or under a different user identity.
     ///
-    /// For multi-user test fixtures only. Real replicas come from disk or sync.
-    #[doc(hidden)]
+    /// The fork shares this project's `uuid` and full log snapshot, but starts
+    /// with no active session. The next `apply_changes` on the fork opens a
+    /// fresh session for `user`. Shared and session data (which are per-replica
+    /// in-memory state) are NOT carried over.
+    ///
+    /// The shared `uuid` is load-bearing: [`Project::merge_remote`] requires
+    /// the two replicas to agree on it, so only replicas produced via
+    /// `fork_replica` (or round-tripped through serde) can be merged back.
     #[must_use]
-    pub fn clone_for_test_replica(&self) -> Self {
+    pub fn fork_replica(&self, user: UserId) -> Self {
         Self {
-            user: UserId::new(),
+            user,
             session: None,
             branch: self.branch,
             lamport_clock: self.lamport_clock,

--- a/crates/project/src/lib.rs
+++ b/crates/project/src/lib.rs
@@ -176,7 +176,6 @@ use std::fmt::Debug;
 
 // Public reexports
 pub use branch::BranchId;
-pub use merge::MergeError;
 pub use checkpoint::CheckpointId;
 pub use data::DataId;
 pub use data::DataView;
@@ -185,6 +184,7 @@ pub use document::DocumentId;
 pub use document::DocumentView;
 pub use document::Path;
 pub use document::PlannedDocument;
+pub use merge::MergeError;
 pub use module_data::ModuleRegistry;
 pub use oplog::{Change, LogEntry, LogPayload};
 pub use project::ProjectView;
@@ -488,8 +488,7 @@ impl Project {
     /// Creates a [`ProjectView`] scoped to a branch and a Lamport-clock cutoff.
     ///
     /// Only log entries with `lamport <= as_of` are included. Each op is
-    /// further gated by the per-op branch visibility rule (see
-    /// [`resolve::op_is_visible`]).
+    /// further gated by the per-op branch visibility check.
     ///
     /// # Errors
     /// Returns an error if a required module is not found in the registry.
@@ -506,11 +505,7 @@ impl Project {
 
         // Sort by (lamport, session) — equivalent to insertion order today, but
         // explicit so the function stays correct after merge_remote.
-        let mut ordered: Vec<&LogEntry> = self
-            .log
-            .iter()
-            .filter(|e| e.lamport <= as_of)
-            .collect();
+        let mut ordered: Vec<&LogEntry> = self.log.iter().filter(|e| e.lamport <= as_of).collect();
         ordered.sort_by_key(|e| (e.lamport, e.session));
 
         // First pass: register sessions so apply_change can resolve UserTransaction.
@@ -546,13 +541,7 @@ impl Project {
                     Some(b) => *b,
                     None => continue,
                 };
-                if !resolve::op_is_visible(
-                    entry.lamport,
-                    op_branch,
-                    branch,
-                    as_of,
-                    &merges_idx,
-                ) {
+                if !resolve::op_is_visible(entry.lamport, op_branch, branch, as_of, &merges_idx) {
                     continue;
                 }
                 for change in changes {
@@ -808,7 +797,10 @@ fn compute_active_keys(ordered: &[&LogEntry]) -> std::collections::HashSet<(u64,
 /// builds. `session_user_map` maps a `SessionId` to the `UserId` that
 /// owns it (populated from `NewSession` entries). `viewer` is the user
 /// the view is being constructed for; this gates `UserTransaction`.
-#[allow(clippy::too_many_arguments, reason = "all params are distinct view-building state; no natural grouping")]
+#[allow(
+    clippy::too_many_arguments,
+    reason = "all params are distinct view-building state; no natural grouping"
+)]
 fn apply_change(
     change: &Change,
     data: &mut HashMap<DataId, module_data::ErasedData>,
@@ -829,9 +821,7 @@ fn apply_change(
                 }
             }
         }
-        Change::RenameDocument { .. }
-        | Change::MoveDocument { .. }
-        | Change::MoveFolder { .. } => {
+        Change::RenameDocument { .. } | Change::MoveDocument { .. } | Change::MoveFolder { .. } => {
             // Pre-existing TODO: folder support. Intentionally no-op.
         }
         Change::CreateData { id, module, owner } => {

--- a/crates/project/src/lib.rs
+++ b/crates/project/src/lib.rs
@@ -11,7 +11,7 @@
 //! - **Data Persistence:** Supports serialization and deserialization of `Project` data, ensuring that project information
 //!   can be saved and loaded reliably.
 //! - **Change Tracking and Version Control:** Implements a robust change tracking system based on a chronological log of
-//!   `ProjectLogEntry`. This enables features like:
+//!   `LogEntry`. This enables features like:
 //!     - Persistent undo/redo functionality.
 //!     - Git-like version control with branching and merging.
 //! - **Extensibility through Modules:** Allows users to define custom data types and behaviors by implementing the `module::Module`
@@ -165,10 +165,8 @@ mod user;
 
 use document::Document;
 use log::error;
-use module_data::{
-    ErasedDataTransactionArgs, ErasedSessionData, ErasedSessionDataTransactionArgs,
-    ErasedSharedDataTransactionArgs, ErasedUserDataTransactionArgs, ModuleId, MODULE_REGISTRY,
-};
+use module_data::{ErasedSessionData, ModuleId, MODULE_REGISTRY};
+use oplog::PendingChange;
 use serde::de::DeserializeSeed;
 use serde::{Deserialize, Deserializer, Serialize};
 use std::collections::HashMap;
@@ -185,7 +183,7 @@ pub use document::DocumentView;
 pub use document::Path;
 pub use document::PlannedDocument;
 pub use module_data::ModuleRegistry;
-pub use oplog::{LogEntry, LogPayload};
+pub use oplog::{Change, LogEntry, LogPayload};
 pub use project::ProjectView;
 pub use tracked::AccessRecorder;
 pub use tracked::CacheValidator;
@@ -231,26 +229,6 @@ where
     }
 }
 
-/// A single change to be applied to the [`Project`].
-#[derive(Clone, Debug)]
-enum PendingChange {
-    Change(Change),
-    SessionTransaction {
-        id: DataId,
-        /// Stores the [`module::DataSection::Args`] for [`module::Module::SessionData`].
-        ///
-        /// The [`module::Module`] is equal to in the last [`Change::CreateData`] with the same [`DataId`].
-        args: ErasedSessionDataTransactionArgs,
-    },
-    SharedTransaction {
-        id: DataId,
-        /// Stores the [`module::DataSection::Args`] for [`module::Module::SharedData`].
-        ///
-        /// The [`module::Module`] is equal to in the last [`Change::CreateData`] with the same [`DataId`].
-        args: ErasedSharedDataTransactionArgs,
-    },
-}
-
 /// Like [`Path`], but also allowing the Root folder
 #[derive(PartialEq, PartialOrd, Eq, Ord, Clone, Debug, Deserialize, Serialize)]
 pub enum FolderPath {
@@ -263,93 +241,6 @@ pub enum FolderTarget {
     Root,
     Path(Path),
     OneBack,
-}
-
-/// A single change persistently applied to the [`Project`].
-#[derive(Clone, Serialize, Deserialize, Debug)]
-enum Change {
-    CreateDocument {
-        id: DocumentId,
-        /// Path of the document as it will be shown to the user.
-        ///
-        /// In case a Document with the given `path` already exists,
-        /// this `path` will automatically be renamed with [`Path::increment_name_suffix`]
-        /// as many times as necessary to avoid duplicates.
-        path: Path,
-    },
-    /// This will delete the document and all data contained in it.
-    DeleteDocument(DocumentId),
-    // rename the document without changing its location.
-    RenameDocument {
-        id: DocumentId,
-        new_name: String,
-    },
-    // Move the document to another location, keeping its name.
-    MoveDocument {
-        id: DocumentId,
-        new_folder: FolderPath,
-    },
-    // All containing folders/documents to a new location.
-    MoveFolder {
-        old_path: Path,
-        new_path: FolderTarget,
-    },
-    CreateData {
-        id: DataId,
-        module: ModuleId,
-        owner: Option<DocumentId>,
-    },
-    DeleteData(DataId),
-    MoveData {
-        id: DataId,
-        new_owner: Option<DocumentId>,
-    },
-    Transaction {
-        // Id of the Data this Transaction should be applied to.
-        //
-        // If `id` does not exist yet or was deleted, this Transaction will be ignored.
-        id: DataId,
-        /// Stores the [`module::DataSection::Args`] for [`module::Module::PersistentData`].
-        ///
-        /// The [`module::Module`] is equal to in the last [`Self::CreateData`] with the same [`DataId`].
-        args: ErasedDataTransactionArgs,
-    },
-    UserTransaction {
-        // Id of the Data this Transaction should be applied to.
-        //
-        // If `id` does not exist yet or was deleted, this Transaction will be ignored.
-        id: DataId,
-        /// Stores the [`module::DataSection::Args`] for [`module::Module::PersistentUserData`].
-        ///
-        /// The [`module::Module`] is equal to in the last [`Self::CreateData`] with the same [`DataId`].
-        args: ErasedUserDataTransactionArgs,
-    },
-}
-
-/// Entry in the log stored in [`Project`]
-#[derive(Clone, Serialize, Deserialize, Debug)]
-// TODO: add data for Ord
-enum ProjectLogEntry {
-    Changes {
-        session: SessionId,
-        changes: Vec<Change>,
-    },
-    /// Tells that the a [`Self::Changes`] before this entry (with the same [`SessionId`]) should be ignored
-    Undo { session: SessionId },
-    /// Tells that a [`Self::Undo`] before this entry (with the same [`SessionId`]) should be ignored
-    Redo { session: SessionId },
-    /// Registers a new [`SessionId`] to associate it with editing of the given user.
-    ///
-    /// All sessions happening on the same branch must also be registered with the same [`BranchId`].
-    ///
-    /// Any in [`Project::log`] used [`SessionId`] must be previously registered using this entry.
-    NewSession {
-        user: UserId,
-        branch: BranchId,
-        new_session: SessionId,
-    },
-    /// Add a named identifier to this position in the [`Project::log`].
-    CheckPoint(CheckpointId),
 }
 
 /// Record changes to be applied to a [`Project`].
@@ -511,7 +402,7 @@ pub struct Project {
     lamport_clock: u64,
     /// Chronological list of entries required to rebuild the entire [`ProjectView`] excluding
     /// shared and session data
-    log: Vec<ProjectLogEntry>,
+    log: Vec<LogEntry>,
     /// [`HashMap`] with all [`module::Module::SharedData`] (of this user) in this project.
     #[serde(skip)]
     shared_data: HashMap<DataId, module_data::ErasedSharedData>,
@@ -587,11 +478,11 @@ impl Project {
     pub fn create_view(&self, reg: &ModuleRegistry) -> Result<ProjectView, ProjectViewError> {
         let mut data = HashMap::new();
         let mut documents = HashMap::new();
-        let mut sessions = HashMap::new();
+        let mut sessions: HashMap<SessionId, UserId> = HashMap::new();
 
-        for log_entry in &self.log {
-            match log_entry {
-                ProjectLogEntry::Changes { session, changes } => {
+        for entry in &self.log {
+            match &entry.payload {
+                LogPayload::Changes(changes) => {
                     for change in changes {
                         apply_change(
                             change,
@@ -599,22 +490,18 @@ impl Project {
                             &mut documents,
                             &sessions,
                             self.user,
-                            *session,
+                            entry.session,
                             reg,
                         )?;
                     }
                 }
-                // TODO: implement and Test undo/redo
-                ProjectLogEntry::Undo { session: _ } => todo!("undo/redo is not supported yet"),
-                ProjectLogEntry::Redo { session: _ } => todo!("undo/redo is not supported yet"),
-                ProjectLogEntry::NewSession {
-                    user,
-                    new_session,
-                    branch: _,
-                } => {
-                    sessions.insert(*new_session, *user);
+                LogPayload::NewSession { user, .. } => {
+                    sessions.insert(entry.session, *user);
                 }
-                ProjectLogEntry::CheckPoint(_) => {}
+                LogPayload::Checkpoint(_)
+                | LogPayload::Undo
+                | LogPayload::Redo
+                | LogPayload::MergeBranch { .. } => {}
             }
         }
 
@@ -694,102 +581,97 @@ impl Project {
         // Technically the project could change in the meantime by other ChangeBuilders,
         // but due to multi-user support, we nevertheless need to support that.
 
-        let session = *self.session.get_or_insert_with(|| {
-            let new_session = SessionId::new();
-            self.log.push(ProjectLogEntry::NewSession {
-                user: self.user,
-                branch: self.branch,
-                new_session,
-            });
-            new_session
-        });
-
-        // Verify all changes first
+        // Verify all module references first.
         for change in &cb.changes {
-            match change {
-                PendingChange::Change(c) => match c {
-                    Change::CreateDocument { id: _, path: _ }
-                    | Change::DeleteDocument(_)
-                    | Change::RenameDocument { id: _, new_name: _ }
-                    | Change::MoveDocument {
-                        id: _,
-                        new_folder: _,
-                    }
-                    | Change::MoveFolder {
-                        old_path: _,
-                        new_path: _,
-                    }
-                    | Change::DeleteData(_)
-                    | Change::MoveData {
-                        id: _,
-                        new_owner: _,
-                    } => {}
-                    Change::CreateData {
-                        id: _,
-                        module,
-                        owner: _,
-                    } => {
-                        if !reg.0.contains_key(module) {
-                            return Err(ApplyError::UnknownModule(*module));
-                        }
-                    }
-                    Change::Transaction { id: _, args } => {
-                        if !reg.0.contains_key(&args.module) {
-                            return Err(ApplyError::UnknownModule(args.module));
-                        }
-                    }
-                    Change::UserTransaction { id: _, args } => {
-                        if !reg.0.contains_key(&args.module) {
-                            return Err(ApplyError::UnknownModule(args.module));
-                        }
-                    }
-                },
-                PendingChange::SessionTransaction { id: _, args } => {
-                    if !reg.0.contains_key(&args.module) {
-                        return Err(ApplyError::UnknownModule(args.module));
+            let module = match change {
+                PendingChange::Change(Change::CreateData { module, .. }) => Some(*module),
+                PendingChange::Change(Change::Transaction { args, .. }) => Some(args.module),
+                PendingChange::Change(Change::UserTransaction { args, .. }) => Some(args.module),
+                PendingChange::SessionTransaction { args, .. } => Some(args.module),
+                PendingChange::SharedTransaction { args, .. } => Some(args.module),
+                _ => None,
+            };
+            if let Some(module) = module {
+                if !reg.0.contains_key(&module) {
+                    return Err(ApplyError::UnknownModule(module));
+                }
+            }
+        }
+
+        let session = self.ensure_session();
+
+        let mut grouped: Vec<Change> = Vec::new();
+        let mut tail_payloads: Vec<LogPayload> = Vec::new();
+
+        for pc in cb.changes {
+            match pc {
+                PendingChange::Change(c) => grouped.push(c),
+                PendingChange::Undo => tail_payloads.push(LogPayload::Undo),
+                PendingChange::Redo => tail_payloads.push(LogPayload::Redo),
+                PendingChange::MergeBranch { from, into } => {
+                    tail_payloads.push(LogPayload::MergeBranch { from, into });
+                }
+                PendingChange::SessionTransaction { id, args } => {
+                    let entry = reg.0.get(&args.module).expect("already checked above");
+                    let data = self
+                        .session_data
+                        .entry(id)
+                        .or_insert_with(|| (entry.init_session_data)());
+                    if let Err(err) = (entry.apply_session_data_transaction)(data, &args) {
+                        error!("Failed to apply SessionData Transaction: {err}");
                     }
                 }
-                PendingChange::SharedTransaction { id: _, args } => {
-                    if !reg.0.contains_key(&args.module) {
-                        return Err(ApplyError::UnknownModule(args.module));
+                PendingChange::SharedTransaction { id, args } => {
+                    let entry = reg.0.get(&args.module).expect("already checked above");
+                    let data = self
+                        .shared_data
+                        .entry(id)
+                        .or_insert_with(|| (entry.init_shared_data)());
+                    if let Err(err) = (entry.apply_shared_data_transaction)(data, &args) {
+                        error!("Failed to apply SharedData Transaction: {err}");
                     }
                 }
             }
         }
 
-        // Now apply the changes
-        let changes = cb
-            .changes
-            .into_iter()
-            .filter_map(|change| match change {
-                PendingChange::Change(change) => Some(change),
-                PendingChange::SessionTransaction { id, args } => {
-                    let reg = reg.0.get(&args.module).expect("already checked above");
-                    let data = self
-                        .session_data
-                        .entry(id)
-                        .or_insert_with(|| (reg.init_session_data)());
-                    if let Err(err) = (reg.apply_session_data_transaction)(data, &args) {
-                        error!("Failed to apply SessionData Transaction: {err}");
-                    }
-                    None
-                }
-                PendingChange::SharedTransaction { id, args } => {
-                    let reg = reg.0.get(&args.module).expect("already checked above");
-                    let data = self
-                        .shared_data
-                        .entry(id)
-                        .or_insert_with(|| (reg.init_shared_data)());
-                    if let Err(err) = (reg.apply_shared_data_transaction)(data, &args) {
-                        error!("Failed to apply SharedData Transaction: {err}");
-                    }
-                    None
-                }
-            })
-            .collect();
+        if !grouped.is_empty() {
+            let head = self.new_entry(session, LogPayload::Changes(grouped));
+            self.log.push(head);
+        }
+        for payload in tail_payloads {
+            let entry = self.new_entry(session, payload);
+            self.log.push(entry);
+        }
 
-        self.log.push(ProjectLogEntry::Changes { session, changes });
         Ok(())
+    }
+
+    fn ensure_session(&mut self) -> SessionId {
+        if let Some(s) = self.session {
+            return s;
+        }
+        let new_session = SessionId::new();
+        let entry = self.new_entry(
+            new_session,
+            LogPayload::NewSession {
+                user: self.user,
+                branch: self.branch,
+            },
+        );
+        self.log.push(entry);
+        self.session = Some(new_session);
+        new_session
+    }
+
+    fn new_entry(&mut self, session: SessionId, payload: LogPayload) -> LogEntry {
+        let lamport = self.lamport_clock;
+        self.lamport_clock += 1;
+        LogEntry {
+            lamport,
+            session,
+            wall_clock: Some(std::time::SystemTime::now()),
+            payload,
+        }
     }
 }
 

--- a/crates/project/src/lib.rs
+++ b/crates/project/src/lib.rs
@@ -620,6 +620,25 @@ impl Project {
         self.session = None;
     }
 
+    /// Current branch this replica is editing on.
+    #[must_use]
+    pub const fn current_branch(&self) -> BranchId {
+        self.branch
+    }
+
+    /// Current session id, if a session has been allocated by `apply_changes`.
+    #[must_use]
+    pub const fn current_session(&self) -> Option<SessionId> {
+        self.session
+    }
+
+    /// Locally switch to `branch`. Does not touch the log; future
+    /// `NewSession` entries tag with the new branch.
+    pub fn switch_branch(&mut self, branch: BranchId) {
+        self.branch = branch;
+        self.reset_session();
+    }
+
     /// Apply the changes recorded using the [`ChangeBuilder`] to this project.
     ///
     /// After applying the changes, use [`Project::create_view`] to see the new state

--- a/crates/project/src/lib.rs
+++ b/crates/project/src/lib.rs
@@ -162,8 +162,6 @@ mod project;
 mod tracked;
 mod user;
 
-use branch::BranchId;
-use checkpoint::CheckpointId;
 use document::Document;
 use log::{error, warn};
 use module_data::{
@@ -174,9 +172,10 @@ use serde::de::DeserializeSeed;
 use serde::{Deserialize, Deserializer, Serialize};
 use std::collections::HashMap;
 use std::fmt::Debug;
-use user::SessionId;
 
 // Public reexports
+pub use branch::BranchId;
+pub use checkpoint::CheckpointId;
 pub use data::DataId;
 pub use data::DataView;
 pub use data::PlannedData;
@@ -191,6 +190,7 @@ pub use tracked::CacheValidator;
 pub use tracked::TrackedDataView;
 pub use tracked::TrackedDocumentView;
 pub use tracked::TrackedProjectView;
+pub use user::SessionId;
 pub use user::UserId;
 
 /// Facilitates the deserialization of a [`Project`] from a serialized format.

--- a/crates/project/src/lib.rs
+++ b/crates/project/src/lib.rs
@@ -158,12 +158,13 @@ mod checkpoint;
 mod data;
 mod document;
 mod module_data;
+mod oplog;
 mod project;
 mod tracked;
 mod user;
 
 use document::Document;
-use log::{error, warn};
+use log::error;
 use module_data::{
     ErasedDataTransactionArgs, ErasedSessionData, ErasedSessionDataTransactionArgs,
     ErasedSharedDataTransactionArgs, ErasedUserDataTransactionArgs, ModuleId, MODULE_REGISTRY,
@@ -184,6 +185,7 @@ pub use document::DocumentView;
 pub use document::Path;
 pub use document::PlannedDocument;
 pub use module_data::ModuleRegistry;
+pub use oplog::{LogEntry, LogPayload};
 pub use project::ProjectView;
 pub use tracked::AccessRecorder;
 pub use tracked::CacheValidator;

--- a/crates/project/src/lib.rs
+++ b/crates/project/src/lib.rs
@@ -503,8 +503,8 @@ impl Project {
         let mut sessions: HashMap<SessionId, UserId> = HashMap::new();
         let mut session_branch: HashMap<SessionId, BranchId> = HashMap::new();
 
-        // Sort by (lamport, session) — equivalent to insertion order today, but
-        // explicit so the function stays correct after merge_remote.
+        // TODO: keep self.log sorted on write so views can skip this O(N log N) sort.
+        // merge_remote could use a 2-pointer merge between sorted halves.
         let mut ordered: Vec<&LogEntry> = self.log.iter().filter(|e| e.lamport <= as_of).collect();
         ordered.sort_by_key(|e| (e.lamport, e.session));
 

--- a/crates/project/src/lib.rs
+++ b/crates/project/src/lib.rs
@@ -360,6 +360,12 @@ impl ChangeBuilder {
     pub fn redo(&mut self) {
         self.changes.push(PendingChange::Redo);
     }
+
+    /// Record a one-shot snapshot merge from `from` into `into`.
+    /// Undoable like any other session-scoped op.
+    pub fn merge_branch(&mut self, from: BranchId, into: BranchId) {
+        self.changes.push(PendingChange::MergeBranch { from, into });
+    }
 }
 
 /// Project in the `CADara` application.
@@ -479,9 +485,9 @@ impl Project {
 
     /// Creates a [`ProjectView`] scoped to a branch and a Lamport-clock cutoff.
     ///
-    /// Only log entries with `lamport <= as_of` are included. Branch filtering is a
-    /// no-op until Task 13 wires `compute_visible_branches`; the parameter is
-    /// accepted here to establish the API surface.
+    /// Only log entries with `lamport <= as_of` are included. Each op is
+    /// further gated by the per-op branch visibility rule (see
+    /// [`resolve::op_is_visible`]).
     ///
     /// # Errors
     /// Returns an error if a required module is not found in the registry.
@@ -513,49 +519,50 @@ impl Project {
             }
         }
 
-        // Branch filter is a no-op until Task 13.
-        let _ = branch;
-        let _ = &session_branch;
-
         // Second pass: per-session active set via the resolver.
-        let mut by_session: HashMap<SessionId, Vec<&LogEntry>> = HashMap::new();
-        for entry in &ordered {
-            by_session.entry(entry.session).or_default().push(entry);
-        }
-        let mut active_key: std::collections::HashSet<(u64, SessionId)> =
-            std::collections::HashSet::new();
-        for session_entries in by_session.values() {
-            for i in resolve::per_session_active_set(session_entries) {
-                let e = session_entries[i];
-                active_key.insert((e.lamport, e.session));
-            }
-        }
+        let active_key = compute_active_keys(&ordered);
 
-        // Third pass: walk in global order, apply active Changes only.
+        // Build the live MergeBranch adjacency for branch visibility.
+        let live_merges: Vec<&LogEntry> = ordered
+            .iter()
+            .copied()
+            .filter(|e| {
+                matches!(e.payload, LogPayload::MergeBranch { .. })
+                    && active_key.contains(&(e.lamport, e.session))
+            })
+            .collect();
+        let merges_idx = resolve::live_merges_index(&live_merges);
+
+        // Third pass: walk in global order, apply active+visible Changes only.
         for entry in &ordered {
             let active = active_key.contains(&(entry.lamport, entry.session));
-            match &entry.payload {
-                LogPayload::Changes(changes) if active => {
-                    for change in changes {
-                        apply_change(
-                            change,
-                            &mut data,
-                            &mut documents,
-                            &sessions,
-                            self.user,
-                            entry.session,
-                            reg,
-                        )?;
-                    }
+            if let LogPayload::Changes(changes) = &entry.payload {
+                if !active {
+                    continue;
                 }
-                LogPayload::Changes(_)
-                | LogPayload::Undo
-                | LogPayload::Redo
-                | LogPayload::NewSession { .. }
-                | LogPayload::Checkpoint(_)
-                | LogPayload::MergeBranch { .. } => {
-                    // Either inactive Changes (skipped), or no view-time effect.
-                    // MergeBranch becomes meaningful in Task 13.
+                let op_branch = match session_branch.get(&entry.session) {
+                    Some(b) => *b,
+                    None => continue,
+                };
+                if !resolve::op_is_visible(
+                    entry.lamport,
+                    op_branch,
+                    branch,
+                    as_of,
+                    &merges_idx,
+                ) {
+                    continue;
+                }
+                for change in changes {
+                    apply_change(
+                        change,
+                        &mut data,
+                        &mut documents,
+                        &sessions,
+                        self.user,
+                        entry.session,
+                        reg,
+                    )?;
                 }
             }
         }
@@ -755,6 +762,23 @@ impl Project {
             payload,
         }
     }
+}
+
+/// Group entries by session and union their per-session active sets into a
+/// global `(lamport, session)` key set.
+fn compute_active_keys(ordered: &[&LogEntry]) -> std::collections::HashSet<(u64, SessionId)> {
+    let mut by_session: HashMap<SessionId, Vec<&LogEntry>> = HashMap::new();
+    for entry in ordered {
+        by_session.entry(entry.session).or_default().push(entry);
+    }
+    let mut active_key = std::collections::HashSet::new();
+    for session_entries in by_session.values() {
+        for i in resolve::per_session_active_set(session_entries) {
+            let e = session_entries[i];
+            active_key.insert((e.lamport, e.session));
+        }
+    }
+    active_key
 }
 
 /// Apply a single `Change` to the in-progress view state.

--- a/crates/project/src/lib.rs
+++ b/crates/project/src/lib.rs
@@ -157,6 +157,7 @@ mod branch;
 mod checkpoint;
 mod data;
 mod document;
+mod merge;
 mod module_data;
 mod oplog;
 mod project;
@@ -175,6 +176,7 @@ use std::fmt::Debug;
 
 // Public reexports
 pub use branch::BranchId;
+pub use merge::MergeError;
 pub use checkpoint::CheckpointId;
 pub use data::DataId;
 pub use data::DataView;

--- a/crates/project/src/lib.rs
+++ b/crates/project/src/lib.rs
@@ -619,6 +619,25 @@ impl Project {
         Self::default()
     }
 
+    /// Fork a second in-memory replica that shares this project's uuid and
+    /// log snapshot, but starts with a fresh user and no session.
+    ///
+    /// For multi-user test fixtures only. Real replicas come from disk or sync.
+    #[doc(hidden)]
+    #[must_use]
+    pub fn clone_for_test_replica(&self) -> Self {
+        Self {
+            user: UserId::new(),
+            session: None,
+            branch: self.branch,
+            lamport_clock: self.lamport_clock,
+            log: self.log.clone(),
+            shared_data: HashMap::new(),
+            session_data: HashMap::new(),
+            uuid: self.uuid,
+        }
+    }
+
     /// Start a fresh session for subsequent changes.
     ///
     /// Call this before a new editing context (new device or new test scope) so

--- a/crates/project/src/lib.rs
+++ b/crates/project/src/lib.rs
@@ -598,6 +598,16 @@ impl Project {
         Self::default()
     }
 
+    /// Start a fresh session for subsequent changes.
+    ///
+    /// Call this before a new editing context (new device or new test scope) so
+    /// the next [`Project::apply_changes`] opens a new session rather than
+    /// continuing the current one.
+    #[allow(clippy::missing_const_for_fn)]
+    pub fn reset_session(&mut self) {
+        self.session = None;
+    }
+
     /// Apply the changes recorded using the [`ChangeBuilder`] to this project.
     ///
     /// After applying the changes, use [`Project::create_view`] to see the new state

--- a/crates/project/src/lib.rs
+++ b/crates/project/src/lib.rs
@@ -449,8 +449,6 @@ pub struct Project {
     #[serde(skip)]
     session_data: HashMap<DataId, ErasedSessionData>,
     /// Unique identifier to associate a project with its views and [`ChangeBuilder`]s
-    #[serde(skip)]
-    #[serde(default = "uuid::Uuid::new_v4")]
     uuid: uuid::Uuid,
 }
 

--- a/crates/project/src/lib.rs
+++ b/crates/project/src/lib.rs
@@ -350,6 +350,16 @@ impl ChangeBuilder {
             Ok(())
         }
     }
+
+    /// Record an `Undo` for the current session. Resolved at `create_view`.
+    pub fn undo(&mut self) {
+        self.changes.push(PendingChange::Undo);
+    }
+
+    /// Record a `Redo` for the current session. Resolved at `create_view`.
+    pub fn redo(&mut self) {
+        self.changes.push(PendingChange::Redo);
+    }
 }
 
 /// Project in the `CADara` application.

--- a/crates/project/src/merge.rs
+++ b/crates/project/src/merge.rs
@@ -37,17 +37,15 @@ impl Project {
         let have: HashSet<(u64, SessionId)> =
             self.log.iter().map(|e| (e.lamport, e.session)).collect();
 
-        let mut max_remote = self.lamport_clock.saturating_sub(1);
         for e in &other.log {
             if !have.contains(&(e.lamport, e.session)) {
                 self.log.push(e.clone());
             }
-            if e.lamport > max_remote {
-                max_remote = e.lamport;
-            }
         }
 
-        self.lamport_clock = self.lamport_clock.max(max_remote + 1);
+        if let Some(m) = other.log.iter().map(|e| e.lamport).max() {
+            self.lamport_clock = self.lamport_clock.max(m + 1);
+        }
         Ok(())
     }
 }

--- a/crates/project/src/merge.rs
+++ b/crates/project/src/merge.rs
@@ -1,0 +1,80 @@
+use crate::module_data::ModuleId;
+use crate::oplog::{Change, LogEntry, LogPayload};
+use crate::user::SessionId;
+use crate::{ModuleRegistry, Project, ProjectSource};
+use std::collections::HashSet;
+
+#[derive(thiserror::Error, Debug)]
+pub enum MergeError {
+    #[error("Cannot merge: replicas belong to different projects.")]
+    DifferentProject,
+    #[error("The module {0} is used in the remote log, but not registered in the registry")]
+    UnknownModule(ModuleId),
+}
+
+impl Project {
+    /// Merge another replica's log into this one. The two `Project`s must
+    /// have the same `uuid`. Idempotent: merging an already-merged log is a
+    /// no-op.
+    ///
+    /// # Errors
+    /// Returns `MergeError::DifferentProject` if the replicas have different uuids.
+    /// Returns `MergeError::UnknownModule` if the remote log references a module
+    /// not present in `reg`.
+    pub fn merge_remote(
+        &mut self,
+        other: &Self,
+        reg: &ModuleRegistry,
+    ) -> Result<(), MergeError> {
+        if !self.is_same_source_as(other) {
+            return Err(MergeError::DifferentProject);
+        }
+
+        // Validate that the registry knows every module referenced in the
+        // remote log.
+        for entry in &other.log {
+            check_entry_modules(entry, reg)?;
+        }
+
+        // Dedup by (lamport, session): the same op from both replicas is
+        // byte-identical.
+        let have: HashSet<(u64, SessionId)> = self
+            .log
+            .iter()
+            .map(|e| (e.lamport, e.session))
+            .collect();
+
+        let mut max_remote = self.lamport_clock.saturating_sub(1);
+        for e in &other.log {
+            if !have.contains(&(e.lamport, e.session)) {
+                self.log.push(e.clone());
+            }
+            if e.lamport > max_remote {
+                max_remote = e.lamport;
+            }
+        }
+
+        self.lamport_clock = self.lamport_clock.max(max_remote + 1);
+        Ok(())
+    }
+}
+
+fn check_entry_modules(entry: &LogEntry, reg: &ModuleRegistry) -> Result<(), MergeError> {
+    if let LogPayload::Changes(changes) = &entry.payload {
+        for c in changes {
+            match c {
+                Change::CreateData { module, .. } if !reg.0.contains_key(module) => {
+                    return Err(MergeError::UnknownModule(*module));
+                }
+                Change::Transaction { args, .. } if !reg.0.contains_key(&args.module) => {
+                    return Err(MergeError::UnknownModule(args.module));
+                }
+                Change::UserTransaction { args, .. } if !reg.0.contains_key(&args.module) => {
+                    return Err(MergeError::UnknownModule(args.module));
+                }
+                _ => {}
+            }
+        }
+    }
+    Ok(())
+}

--- a/crates/project/src/merge.rs
+++ b/crates/project/src/merge.rs
@@ -21,11 +21,7 @@ impl Project {
     /// Returns `MergeError::DifferentProject` if the replicas have different uuids.
     /// Returns `MergeError::UnknownModule` if the remote log references a module
     /// not present in `reg`.
-    pub fn merge_remote(
-        &mut self,
-        other: &Self,
-        reg: &ModuleRegistry,
-    ) -> Result<(), MergeError> {
+    pub fn merge_remote(&mut self, other: &Self, reg: &ModuleRegistry) -> Result<(), MergeError> {
         if !self.is_same_source_as(other) {
             return Err(MergeError::DifferentProject);
         }
@@ -38,11 +34,8 @@ impl Project {
 
         // Dedup by (lamport, session): the same op from both replicas is
         // byte-identical.
-        let have: HashSet<(u64, SessionId)> = self
-            .log
-            .iter()
-            .map(|e| (e.lamport, e.session))
-            .collect();
+        let have: HashSet<(u64, SessionId)> =
+            self.log.iter().map(|e| (e.lamport, e.session)).collect();
 
         let mut max_remote = self.lamport_clock.saturating_sub(1);
         for e in &other.log {

--- a/crates/project/src/oplog.rs
+++ b/crates/project/src/oplog.rs
@@ -18,7 +18,7 @@ use std::time::SystemTime;
 /// Single entry in the project's log.
 ///
 /// Replicas converge by sorting their union by `(lamport, session)`.
-/// `wall_clock` is display-only and never read by replay; see the CRDT design spec.
+/// `wall_clock` is display-only and never read by replay.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct LogEntry {
     pub(crate) lamport: u64,

--- a/crates/project/src/oplog.rs
+++ b/crates/project/src/oplog.rs
@@ -15,7 +15,7 @@ use crate::{DataId, DocumentId, FolderPath, FolderTarget, Path};
 use serde::{Deserialize, Serialize};
 use std::time::SystemTime;
 
-/// Single entry in [`Project::log`](crate::Project::log).
+/// Single entry in the project's log.
 ///
 /// Replicas converge by sorting their union by `(lamport, session)`.
 /// `wall_clock` is display-only and never read by replay; see the CRDT design spec.
@@ -99,7 +99,10 @@ pub(crate) enum PendingChange {
     Change(Change),
     Undo,
     Redo,
-    MergeBranch { from: BranchId, into: BranchId },
+    MergeBranch {
+        from: BranchId,
+        into: BranchId,
+    },
     SessionTransaction {
         id: DataId,
         args: ErasedSessionDataTransactionArgs,

--- a/crates/project/src/oplog.rs
+++ b/crates/project/src/oplog.rs
@@ -42,6 +42,10 @@ pub enum LogPayload {
     /// the log before any other entry referring to its `SessionId`.
     NewSession { user: UserId, branch: BranchId },
     /// Named position in the log. Display/audit only.
+    // Future: rich metadata (title, description, author note) could live in a
+    // dedicated `CheckpointModule` whose persistent data is a
+    // `HashMap<CheckpointId, CheckpointInfo>`, matching the existing module
+    // pattern. The id stays opaque; modules attach the rest.
     Checkpoint(CheckpointId),
     /// Declare a one-shot snapshot import of `from` into `into`. Undoable.
     MergeBranch { from: BranchId, into: BranchId },

--- a/crates/project/src/oplog.rs
+++ b/crates/project/src/oplog.rs
@@ -4,10 +4,6 @@
 //! Replicas that have seen the same set of entries produce identical
 //! `Vec<LogEntry>` after sort by `(lamport, session)`.
 
-// Transitional: types in this file are consumed starting in the schema-migration task.
-#![allow(dead_code)]
-#![allow(clippy::redundant_pub_crate)]
-
 use crate::branch::BranchId;
 use crate::checkpoint::CheckpointId;
 use crate::module_data::{
@@ -95,11 +91,18 @@ pub enum Change {
 ///
 /// `SessionTransaction` and `SharedTransaction` are applied to in-memory
 /// shared/session state at `apply_changes` time without going into the log.
+// Only used within this crate; pub(crate) is the right visibility but
+// clippy's redundant_pub_crate fires inside a private module.
+#[allow(clippy::redundant_pub_crate)]
 #[derive(Clone, Debug)]
 pub(crate) enum PendingChange {
     Change(Change),
+    // Wired up in a follow-up task; producers do not exist yet.
+    #[allow(dead_code)]
     Undo,
+    #[allow(dead_code)]
     Redo,
+    #[allow(dead_code)]
     MergeBranch { from: BranchId, into: BranchId },
     SessionTransaction {
         id: DataId,

--- a/crates/project/src/oplog.rs
+++ b/crates/project/src/oplog.rs
@@ -99,7 +99,6 @@ pub(crate) enum PendingChange {
     Change(Change),
     Undo,
     Redo,
-    #[allow(dead_code)]
     MergeBranch { from: BranchId, into: BranchId },
     SessionTransaction {
         id: DataId,

--- a/crates/project/src/oplog.rs
+++ b/crates/project/src/oplog.rs
@@ -97,10 +97,7 @@ pub enum Change {
 #[derive(Clone, Debug)]
 pub(crate) enum PendingChange {
     Change(Change),
-    // Wired up in a follow-up task; producers do not exist yet.
-    #[allow(dead_code)]
     Undo,
-    #[allow(dead_code)]
     Redo,
     #[allow(dead_code)]
     MergeBranch { from: BranchId, into: BranchId },

--- a/crates/project/src/oplog.rs
+++ b/crates/project/src/oplog.rs
@@ -1,0 +1,112 @@
+//! On-disk log entry shape for the CRDT layer.
+//!
+//! Each [`LogEntry`] carries a totally-ordered `(lamport, session)` key.
+//! Replicas that have seen the same set of entries produce identical
+//! `Vec<LogEntry>` after sort by `(lamport, session)`.
+
+// Transitional: types in this file are consumed starting in the schema-migration task.
+#![allow(dead_code)]
+#![allow(clippy::redundant_pub_crate)]
+
+use crate::branch::BranchId;
+use crate::checkpoint::CheckpointId;
+use crate::module_data::{
+    ErasedDataTransactionArgs, ErasedSessionDataTransactionArgs, ErasedSharedDataTransactionArgs,
+    ErasedUserDataTransactionArgs, ModuleId,
+};
+use crate::user::{SessionId, UserId};
+use crate::{DataId, DocumentId, FolderPath, FolderTarget, Path};
+use serde::{Deserialize, Serialize};
+use std::time::SystemTime;
+
+/// Single entry in [`Project::log`](crate::Project::log).
+///
+/// Replicas converge by sorting their union by `(lamport, session)`.
+/// `wall_clock` is display-only and never read by replay; see the CRDT design spec.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct LogEntry {
+    pub(crate) lamport: u64,
+    pub(crate) session: SessionId,
+    #[serde(default)]
+    pub(crate) wall_clock: Option<SystemTime>,
+    pub(crate) payload: LogPayload,
+}
+
+/// What a [`LogEntry`] carries.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub enum LogPayload {
+    /// Atomic group of changes recorded by one [`ChangeBuilder`](crate::ChangeBuilder)
+    /// application. Undoable as one unit.
+    Changes(Vec<Change>),
+    /// Cancel the most recent live `Changes` or `MergeBranch` from this session.
+    Undo,
+    /// Reinstate the most recently cancelled entry from this session (LIFO).
+    Redo,
+    /// Declare a new session belonging to `user` on `branch`. Must appear in
+    /// the log before any other entry referring to its `SessionId`.
+    NewSession { user: UserId, branch: BranchId },
+    /// Named position in the log. Display/audit only.
+    Checkpoint(CheckpointId),
+    /// Declare a one-shot snapshot import of `from` into `into`. Undoable.
+    MergeBranch { from: BranchId, into: BranchId },
+}
+
+/// One change to the persistent state of a [`Project`](crate::Project).
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub enum Change {
+    CreateDocument {
+        id: DocumentId,
+        path: Path,
+    },
+    DeleteDocument(DocumentId),
+    RenameDocument {
+        id: DocumentId,
+        new_name: String,
+    },
+    MoveDocument {
+        id: DocumentId,
+        new_folder: FolderPath,
+    },
+    MoveFolder {
+        old_path: Path,
+        new_path: FolderTarget,
+    },
+    CreateData {
+        id: DataId,
+        module: ModuleId,
+        owner: Option<DocumentId>,
+    },
+    DeleteData(DataId),
+    MoveData {
+        id: DataId,
+        new_owner: Option<DocumentId>,
+    },
+    Transaction {
+        id: DataId,
+        args: ErasedDataTransactionArgs,
+    },
+    UserTransaction {
+        id: DataId,
+        args: ErasedUserDataTransactionArgs,
+    },
+}
+
+/// Non-persistent pending change recorded in a [`ChangeBuilder`](crate::ChangeBuilder).
+///
+/// `SessionTransaction` and `SharedTransaction` are applied to in-memory
+/// shared/session state at `apply_changes` time without going into the log.
+#[derive(Clone, Debug)]
+pub(crate) enum PendingChange {
+    Change(Change),
+    Undo,
+    Redo,
+    MergeBranch { from: BranchId, into: BranchId },
+    SessionTransaction {
+        id: DataId,
+        args: ErasedSessionDataTransactionArgs,
+    },
+    SharedTransaction {
+        id: DataId,
+        args: ErasedSharedDataTransactionArgs,
+    },
+}

--- a/crates/project/src/oplog.rs
+++ b/crates/project/src/oplog.rs
@@ -101,12 +101,6 @@ pub enum Change {
 #[derive(Clone, Debug)]
 pub(crate) enum PendingChange {
     Change(Change),
-    Undo,
-    Redo,
-    MergeBranch {
-        from: BranchId,
-        into: BranchId,
-    },
     SessionTransaction {
         id: DataId,
         args: ErasedSessionDataTransactionArgs,

--- a/crates/project/src/resolve.rs
+++ b/crates/project/src/resolve.rs
@@ -1,4 +1,6 @@
-//! Pure resolvers for Layers 1 and 2 of the CRDT design.
+//! Pure resolvers for layers 1 and 2 of the project's CRDT architecture.
+//!
+//! See the crate-level docs for what the layers are.
 
 use crate::branch::BranchId;
 use crate::oplog::{LogEntry, LogPayload};
@@ -6,6 +8,11 @@ use std::collections::{BTreeSet, HashMap, HashSet, VecDeque};
 
 /// Walk a session's entries (already lamport-sorted) and return the indices
 /// (into `entries`) whose effect is currently active.
+///
+/// Undo and Redo are inherently scoped to the issuing session: this function
+/// receives only one session's entries, so an `Undo` entry can only target
+/// `Changes` or `MergeBranch` entries from the same session. Multi-user safety
+/// (one user's undo can't touch another's edits) follows for free.
 ///
 /// Only `Changes` and `MergeBranch` payloads occupy the active/redo
 /// bookkeeping. `Undo` and `Redo` mutate that bookkeeping. Other payloads
@@ -49,7 +56,7 @@ pub fn op_is_visible(
     if op_branch == view_branch {
         return true;
     }
-    // BFS from view_branch over reverse-merge edges. Per the spec, EVERY hop
+    // BFS from view_branch over reverse-merge edges. Every hop
     // along the chain must satisfy op_lamport < merge_lamport (the op was
     // already on the source branch when that merge happened) AND
     // merge_lamport <= as_of. The hop ending at op_branch is the one that

--- a/crates/project/src/resolve.rs
+++ b/crates/project/src/resolve.rs
@@ -2,8 +2,7 @@
 
 use crate::branch::BranchId;
 use crate::oplog::{LogEntry, LogPayload};
-use crate::user::SessionId;
-use std::collections::{BTreeSet, HashMap, HashSet};
+use std::collections::{BTreeSet, HashMap, HashSet, VecDeque};
 
 /// Walk a session's entries (already lamport-sorted) and return the indices
 /// (into `entries`) whose effect is currently active.
@@ -38,22 +37,54 @@ pub fn per_session_active_set(entries: &[&LogEntry]) -> BTreeSet<usize> {
     active
 }
 
-/// Compute the set of branches transitively merged into `view_branch` as of
-/// `as_of`, considering only `MergeBranch` entries that are *live* under each
-/// originating session's per-session resolution.
-///
-/// Placeholder: this is wired up in Task 13. For now, returns the singleton
-/// containing `view_branch`.
-#[allow(dead_code, reason = "consumed by create_view in the next task")]
-pub fn compute_visible_branches(
-    log: &[LogEntry],
+/// Returns true if op `(op_lamport, op_branch)` is visible from `view_branch`
+/// at view time `as_of`, given an index of live `MergeBranch` entries.
+pub fn op_is_visible(
+    op_lamport: u64,
+    op_branch: BranchId,
     view_branch: BranchId,
     as_of: u64,
-    session_branch: &HashMap<SessionId, BranchId>,
-    live_merges: &[&LogEntry],
-) -> HashSet<BranchId> {
-    let _ = (log, as_of, session_branch, live_merges);
-    let mut visible = HashSet::new();
-    visible.insert(view_branch);
-    visible
+    live_merges_by_into: &HashMap<BranchId, Vec<(BranchId, u64)>>,
+) -> bool {
+    if op_branch == view_branch {
+        return true;
+    }
+    // BFS from view_branch over reverse-merge edges. Per the spec, EVERY hop
+    // along the chain must satisfy op_lamport < merge_lamport (the op was
+    // already on the source branch when that merge happened) AND
+    // merge_lamport <= as_of. The hop ending at op_branch is the one that
+    // imports the op.
+    let mut frontier: VecDeque<BranchId> = VecDeque::new();
+    frontier.push_back(view_branch);
+    let mut seen: HashSet<BranchId> = HashSet::new();
+    seen.insert(view_branch);
+
+    while let Some(branch) = frontier.pop_front() {
+        if let Some(merges) = live_merges_by_into.get(&branch) {
+            for &(from, merge_lamport) in merges {
+                if merge_lamport > as_of || op_lamport >= merge_lamport {
+                    continue;
+                }
+                if from == op_branch {
+                    return true;
+                }
+                if seen.insert(from) {
+                    frontier.push_back(from);
+                }
+            }
+        }
+    }
+    false
+}
+
+/// Build the `into -> [(from, merge_lamport)]` adjacency from a slice of
+/// live `MergeBranch` log entries.
+pub fn live_merges_index(live: &[&LogEntry]) -> HashMap<BranchId, Vec<(BranchId, u64)>> {
+    let mut out: HashMap<BranchId, Vec<(BranchId, u64)>> = HashMap::new();
+    for entry in live {
+        if let LogPayload::MergeBranch { from, into } = entry.payload {
+            out.entry(into).or_default().push((from, entry.lamport));
+        }
+    }
+    out
 }

--- a/crates/project/src/resolve.rs
+++ b/crates/project/src/resolve.rs
@@ -11,7 +11,6 @@ use std::collections::{BTreeSet, HashMap, HashSet};
 /// Only `Changes` and `MergeBranch` payloads occupy the active/redo
 /// bookkeeping. `Undo` and `Redo` mutate that bookkeeping. Other payloads
 /// (`NewSession`, `Checkpoint`) are ignored at this layer.
-#[allow(dead_code, reason = "consumed by create_view in the next task")]
 pub fn per_session_active_set(entries: &[&LogEntry]) -> BTreeSet<usize> {
     let mut active: BTreeSet<usize> = BTreeSet::new();
     let mut redo_buf: Vec<usize> = Vec::new();

--- a/crates/project/src/resolve.rs
+++ b/crates/project/src/resolve.rs
@@ -4,7 +4,7 @@
 
 use crate::branch::BranchId;
 use crate::oplog::{LogEntry, LogPayload};
-use std::collections::{BTreeSet, HashMap, HashSet, VecDeque};
+use std::collections::{BTreeSet, HashMap, VecDeque};
 
 /// Walk a session's entries (already lamport-sorted) and return the indices
 /// (into `entries`) whose effect is currently active.
@@ -56,27 +56,40 @@ pub fn op_is_visible(
     if op_branch == view_branch {
         return true;
     }
-    // BFS from view_branch over reverse-merge edges. Every hop
-    // along the chain must satisfy op_lamport < merge_lamport (the op was
-    // already on the source branch when that merge happened) AND
-    // merge_lamport <= as_of. The hop ending at op_branch is the one that
-    // imports the op.
-    let mut frontier: VecDeque<BranchId> = VecDeque::new();
-    frontier.push_back(view_branch);
-    let mut seen: HashSet<BranchId> = HashSet::new();
-    seen.insert(view_branch);
+    // BFS over reverse-merge edges starting from view_branch. Each BFS state
+    // carries the branch and an upper bound on the next hop's lamport: the
+    // lamport of the merge that landed us on this branch. The first hop is
+    // bounded by `as_of + 1`, so the gate `merge_lamport < upper_bound` plus
+    // `merge_lamport <= as_of` collapse into a single comparison.
+    //
+    // The op must already be present on each source branch at the moment the
+    // merge ran, so we also gate `op_lamport < merge_lamport` at every hop.
+    // The last hop imports the op when `from == op_branch`.
+    let initial_bound = as_of.saturating_add(1);
+    let mut frontier: VecDeque<(BranchId, u64)> = VecDeque::new();
+    frontier.push_back((view_branch, initial_bound));
+    // Track the highest upper bound each branch has been visited with. A new
+    // visit is only worth enqueuing if it raises that bound, since a larger
+    // bound strictly expands the set of merges reachable from there.
+    let mut best_bound: HashMap<BranchId, u64> = HashMap::new();
+    best_bound.insert(view_branch, initial_bound);
 
-    while let Some(branch) = frontier.pop_front() {
+    while let Some((branch, upper_bound)) = frontier.pop_front() {
         if let Some(merges) = live_merges_by_into.get(&branch) {
             for &(from, merge_lamport) in merges {
-                if merge_lamport > as_of || op_lamport >= merge_lamport {
+                if merge_lamport >= upper_bound {
+                    continue;
+                }
+                if op_lamport >= merge_lamport {
                     continue;
                 }
                 if from == op_branch {
                     return true;
                 }
-                if seen.insert(from) {
-                    frontier.push_back(from);
+                let prev = best_bound.get(&from).copied().unwrap_or(0);
+                if merge_lamport > prev {
+                    best_bound.insert(from, merge_lamport);
+                    frontier.push_back((from, merge_lamport));
                 }
             }
         }

--- a/crates/project/src/resolve.rs
+++ b/crates/project/src/resolve.rs
@@ -1,0 +1,60 @@
+//! Pure resolvers for Layers 1 and 2 of the CRDT design.
+
+use crate::branch::BranchId;
+use crate::oplog::{LogEntry, LogPayload};
+use crate::user::SessionId;
+use std::collections::{BTreeSet, HashMap, HashSet};
+
+/// Walk a session's entries (already lamport-sorted) and return the indices
+/// (into `entries`) whose effect is currently active.
+///
+/// Only `Changes` and `MergeBranch` payloads occupy the active/redo
+/// bookkeeping. `Undo` and `Redo` mutate that bookkeeping. Other payloads
+/// (`NewSession`, `Checkpoint`) are ignored at this layer.
+#[allow(dead_code, reason = "consumed by create_view in the next task")]
+pub fn per_session_active_set(entries: &[&LogEntry]) -> BTreeSet<usize> {
+    let mut active: BTreeSet<usize> = BTreeSet::new();
+    let mut redo_buf: Vec<usize> = Vec::new();
+
+    for (i, entry) in entries.iter().enumerate() {
+        match entry.payload {
+            LogPayload::Changes(_) | LogPayload::MergeBranch { .. } => {
+                active.insert(i);
+            }
+            LogPayload::Undo => {
+                if let Some(&j) = active.iter().next_back() {
+                    active.remove(&j);
+                    redo_buf.push(j);
+                }
+            }
+            LogPayload::Redo => {
+                if let Some(j) = redo_buf.pop() {
+                    active.insert(j);
+                }
+            }
+            LogPayload::NewSession { .. } | LogPayload::Checkpoint(_) => {}
+        }
+    }
+
+    active
+}
+
+/// Compute the set of branches transitively merged into `view_branch` as of
+/// `as_of`, considering only `MergeBranch` entries that are *live* under each
+/// originating session's per-session resolution.
+///
+/// Placeholder: this is wired up in Task 13. For now, returns the singleton
+/// containing `view_branch`.
+#[allow(dead_code, reason = "consumed by create_view in the next task")]
+pub fn compute_visible_branches(
+    log: &[LogEntry],
+    view_branch: BranchId,
+    as_of: u64,
+    session_branch: &HashMap<SessionId, BranchId>,
+    live_merges: &[&LogEntry],
+) -> HashSet<BranchId> {
+    let _ = (log, as_of, session_branch, live_merges);
+    let mut visible = HashSet::new();
+    visible.insert(view_branch);
+    visible
+}

--- a/crates/project/src/user.rs
+++ b/crates/project/src/user.rs
@@ -35,7 +35,7 @@ impl Default for UserId {
 /// Unique identifier to associate changes with the origin.
 ///
 /// We don't directly associate project changes to a [`UserId`], but to a
-/// [`SessionId`] registered to it through [`crate::ProjectLogEntry::NewSession`].
+/// [`SessionId`] registered to it through [`crate::LogPayload::NewSession`].
 ///
 /// This has two main advantages:
 /// - undo/redo will be limited to a single session, meaning: A single user can have
@@ -49,9 +49,12 @@ pub struct SessionId(Uuid);
 impl SessionId {
     /// Create a new random unique identifier of a Session.
     ///
-    /// Before use, this must first be registered in [`crate::ProjectLogEntry::NewSession`].
+    /// Before use, this must first be registered in [`crate::LogPayload::NewSession`].
     #[must_use]
-    #[allow(clippy::new_without_default, reason = "SessionId must be registered before use; no sensible default")]
+    #[allow(
+        clippy::new_without_default,
+        reason = "SessionId must be registered before use; no sensible default"
+    )]
     pub fn new() -> Self {
         Self(Uuid::new_v4())
     }

--- a/crates/project/src/user.rs
+++ b/crates/project/src/user.rs
@@ -42,7 +42,7 @@ impl Default for UserId {
 ///   multiple simultaneous sessions with separate undo/redo history.
 /// - merging multiple branches of the same user will not have spooky effects due to
 ///   incorrectly associated undo/redo commands.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 #[serde(transparent)]
 pub struct SessionId(Uuid);
 

--- a/crates/project/src/user.rs
+++ b/crates/project/src/user.rs
@@ -51,6 +51,7 @@ impl SessionId {
     ///
     /// Before use, this must first be registered in [`crate::ProjectLogEntry::NewSession`].
     #[must_use]
+    #[allow(clippy::new_without_default, reason = "SessionId must be registered before use; no sensible default")]
     pub fn new() -> Self {
         Self(Uuid::new_v4())
     }

--- a/crates/project/tests/branching.rs
+++ b/crates/project/tests/branching.rs
@@ -45,9 +45,7 @@ fn edits_on_unmerged_branch_invisible_from_main() {
     let feature = BranchId::new();
 
     // Fork: give feature visibility of main's current state.
-    let mut cb = ChangeBuilder::from(&project);
-    cb.merge_branch(main, feature);
-    project.apply_changes(cb, &reg).unwrap();
+    project.merge_branch(main, feature);
 
     project.switch_branch(feature);
     let mut cb = ChangeBuilder::from(&project);
@@ -81,9 +79,7 @@ fn merge_branch_imports_snapshot() {
     project.apply_changes(cb, &reg).unwrap();
 
     // Fork: give feature visibility of main's current state.
-    let mut cb = ChangeBuilder::from(&project);
-    cb.merge_branch(main, feature);
-    project.apply_changes(cb, &reg).unwrap();
+    project.merge_branch(main, feature);
 
     project.switch_branch(feature);
     let mut cb = ChangeBuilder::from(&project);
@@ -94,9 +90,7 @@ fn merge_branch_imports_snapshot() {
     project.apply_changes(cb, &reg).unwrap();
 
     project.switch_branch(main);
-    let mut cb = ChangeBuilder::from(&project);
-    cb.merge_branch(feature, main);
-    project.apply_changes(cb, &reg).unwrap();
+    project.merge_branch(feature, main);
 
     assert_eq!(read_num(&project, &reg, main, data_id), 7);
 }
@@ -120,9 +114,7 @@ fn edits_after_merge_not_visible_until_re_merge() {
     project.apply_changes(cb, &reg).unwrap();
 
     // Fork: give feature visibility of main's current state.
-    let mut cb = ChangeBuilder::from(&project);
-    cb.merge_branch(main, feature);
-    project.apply_changes(cb, &reg).unwrap();
+    project.merge_branch(main, feature);
 
     project.switch_branch(feature);
     let mut cb = ChangeBuilder::from(&project);
@@ -133,9 +125,7 @@ fn edits_after_merge_not_visible_until_re_merge() {
     project.apply_changes(cb, &reg).unwrap();
 
     project.switch_branch(main);
-    let mut cb = ChangeBuilder::from(&project);
-    cb.merge_branch(feature, main);
-    project.apply_changes(cb, &reg).unwrap();
+    project.merge_branch(feature, main);
 
     project.switch_branch(feature);
     let mut cb = ChangeBuilder::from(&project);
@@ -148,9 +138,7 @@ fn edits_after_merge_not_visible_until_re_merge() {
     assert_eq!(read_num(&project, &reg, main, data_id), 5);
 
     project.switch_branch(main);
-    let mut cb = ChangeBuilder::from(&project);
-    cb.merge_branch(feature, main);
-    project.apply_changes(cb, &reg).unwrap();
+    project.merge_branch(feature, main);
     assert_eq!(read_num(&project, &reg, main, data_id), 11);
 }
 
@@ -173,9 +161,7 @@ fn undo_of_merge_branch_hides_imported_ops() {
     project.apply_changes(cb, &reg).unwrap();
 
     // Fork: give feature visibility of main's current state.
-    let mut cb = ChangeBuilder::from(&project);
-    cb.merge_branch(main, feature);
-    project.apply_changes(cb, &reg).unwrap();
+    project.merge_branch(main, feature);
 
     project.switch_branch(feature);
     let mut cb = ChangeBuilder::from(&project);
@@ -188,19 +174,13 @@ fn undo_of_merge_branch_hides_imported_ops() {
     // Reset session so undo targets only the merge, not the CreateDocument/CreateData setup.
     project.switch_branch(main);
     project.reset_session();
-    let mut cb = ChangeBuilder::from(&project);
-    cb.merge_branch(feature, main);
-    project.apply_changes(cb, &reg).unwrap();
+    project.merge_branch(feature, main);
     assert_eq!(read_num(&project, &reg, main, data_id), 9);
 
-    let mut cb = ChangeBuilder::from(&project);
-    cb.undo();
-    project.apply_changes(cb, &reg).unwrap();
+    project.undo();
     assert_eq!(read_num(&project, &reg, main, data_id), 0);
 
-    let mut cb = ChangeBuilder::from(&project);
-    cb.redo();
-    project.apply_changes(cb, &reg).unwrap();
+    project.redo();
     assert_eq!(read_num(&project, &reg, main, data_id), 9);
 }
 
@@ -227,14 +207,10 @@ fn multi_hop_merge_respects_per_hop_snapshot_order() {
 
     // Bring main's setup into feature and hot so each branch has the data.
     project.switch_branch(feature);
-    let mut cb = ChangeBuilder::from(&project);
-    cb.merge_branch(main, feature);
-    project.apply_changes(cb, &reg).unwrap();
+    project.merge_branch(main, feature);
 
     project.switch_branch(hot);
-    let mut cb = ChangeBuilder::from(&project);
-    cb.merge_branch(main, hot);
-    project.apply_changes(cb, &reg).unwrap();
+    project.merge_branch(main, hot);
 
     // hot edits the data.
     let mut cb = ChangeBuilder::from(&project);
@@ -246,15 +222,11 @@ fn multi_hop_merge_respects_per_hop_snapshot_order() {
 
     // Merge feature -> main FIRST (feature has no edits from hot yet).
     project.switch_branch(main);
-    let mut cb = ChangeBuilder::from(&project);
-    cb.merge_branch(feature, main);
-    project.apply_changes(cb, &reg).unwrap();
+    project.merge_branch(feature, main);
 
     // Then merge hot -> feature (introducing hot's edit into feature).
     project.switch_branch(feature);
-    let mut cb = ChangeBuilder::from(&project);
-    cb.merge_branch(hot, feature);
-    project.apply_changes(cb, &reg).unwrap();
+    project.merge_branch(hot, feature);
 
     // Main should still see the default value: hot's edit got into feature
     // AFTER feature was merged into main, so main never absorbed it.

--- a/crates/project/tests/branching.rs
+++ b/crates/project/tests/branching.rs
@@ -1,0 +1,205 @@
+mod common;
+
+use common::*;
+use project::{BranchId, ChangeBuilder, ModuleRegistry, Project};
+
+fn fresh_project() -> (Project, ModuleRegistry) {
+    let mut reg = ModuleRegistry::new();
+    reg.register::<MinimalTestModule>();
+    (Project::new(), reg)
+}
+
+fn read_num(
+    project: &Project,
+    reg: &ModuleRegistry,
+    branch: BranchId,
+    data_id: project::DataId,
+) -> i32 {
+    project
+        .create_view_at(reg, branch, u64::MAX)
+        .unwrap()
+        .open_data_by_id::<MinimalTestModule>(data_id)
+        .unwrap()
+        .persistent
+        .num
+}
+
+#[test]
+fn edits_on_unmerged_branch_invisible_from_main() {
+    let (mut project, reg) = fresh_project();
+
+    let mut cb = ChangeBuilder::from(&project);
+    let view = project.create_view(&reg).unwrap();
+    let doc = *view.create_document(&mut cb, "/d".try_into().unwrap());
+    project.apply_changes(cb, &reg).unwrap();
+
+    let mut cb = ChangeBuilder::from(&project);
+    let view = project.create_view(&reg).unwrap();
+    let data_id = *view
+        .open_document(doc)
+        .unwrap()
+        .create_data::<MinimalTestModule>(&mut cb);
+    project.apply_changes(cb, &reg).unwrap();
+
+    let main = project.current_branch();
+    let feature = BranchId::new();
+
+    // Fork: give feature visibility of main's current state.
+    let mut cb = ChangeBuilder::from(&project);
+    cb.merge_branch(main, feature);
+    project.apply_changes(cb, &reg).unwrap();
+
+    project.switch_branch(feature);
+    let mut cb = ChangeBuilder::from(&project);
+    let view = project.create_view(&reg).unwrap();
+    view.open_data_by_id::<MinimalTestModule>(data_id)
+        .unwrap()
+        .apply_persistent(42, &mut cb);
+    project.apply_changes(cb, &reg).unwrap();
+
+    assert_eq!(read_num(&project, &reg, main, data_id), 0);
+    assert_eq!(read_num(&project, &reg, feature, data_id), 42);
+}
+
+#[test]
+fn merge_branch_imports_snapshot() {
+    let (mut project, reg) = fresh_project();
+    let main = project.current_branch();
+    let feature = BranchId::new();
+
+    let mut cb = ChangeBuilder::from(&project);
+    let view = project.create_view(&reg).unwrap();
+    let doc = *view.create_document(&mut cb, "/d".try_into().unwrap());
+    project.apply_changes(cb, &reg).unwrap();
+
+    let mut cb = ChangeBuilder::from(&project);
+    let view = project.create_view(&reg).unwrap();
+    let data_id = *view
+        .open_document(doc)
+        .unwrap()
+        .create_data::<MinimalTestModule>(&mut cb);
+    project.apply_changes(cb, &reg).unwrap();
+
+    // Fork: give feature visibility of main's current state.
+    let mut cb = ChangeBuilder::from(&project);
+    cb.merge_branch(main, feature);
+    project.apply_changes(cb, &reg).unwrap();
+
+    project.switch_branch(feature);
+    let mut cb = ChangeBuilder::from(&project);
+    let view = project.create_view(&reg).unwrap();
+    view.open_data_by_id::<MinimalTestModule>(data_id)
+        .unwrap()
+        .apply_persistent(7, &mut cb);
+    project.apply_changes(cb, &reg).unwrap();
+
+    project.switch_branch(main);
+    let mut cb = ChangeBuilder::from(&project);
+    cb.merge_branch(feature, main);
+    project.apply_changes(cb, &reg).unwrap();
+
+    assert_eq!(read_num(&project, &reg, main, data_id), 7);
+}
+
+#[test]
+fn edits_after_merge_not_visible_until_re_merge() {
+    let (mut project, reg) = fresh_project();
+    let main = project.current_branch();
+    let feature = BranchId::new();
+
+    let mut cb = ChangeBuilder::from(&project);
+    let view = project.create_view(&reg).unwrap();
+    let doc = *view.create_document(&mut cb, "/d".try_into().unwrap());
+    project.apply_changes(cb, &reg).unwrap();
+    let mut cb = ChangeBuilder::from(&project);
+    let view = project.create_view(&reg).unwrap();
+    let data_id = *view
+        .open_document(doc)
+        .unwrap()
+        .create_data::<MinimalTestModule>(&mut cb);
+    project.apply_changes(cb, &reg).unwrap();
+
+    // Fork: give feature visibility of main's current state.
+    let mut cb = ChangeBuilder::from(&project);
+    cb.merge_branch(main, feature);
+    project.apply_changes(cb, &reg).unwrap();
+
+    project.switch_branch(feature);
+    let mut cb = ChangeBuilder::from(&project);
+    let view = project.create_view(&reg).unwrap();
+    view.open_data_by_id::<MinimalTestModule>(data_id)
+        .unwrap()
+        .apply_persistent(5, &mut cb);
+    project.apply_changes(cb, &reg).unwrap();
+
+    project.switch_branch(main);
+    let mut cb = ChangeBuilder::from(&project);
+    cb.merge_branch(feature, main);
+    project.apply_changes(cb, &reg).unwrap();
+
+    project.switch_branch(feature);
+    let mut cb = ChangeBuilder::from(&project);
+    let view = project.create_view(&reg).unwrap();
+    view.open_data_by_id::<MinimalTestModule>(data_id)
+        .unwrap()
+        .apply_persistent(11, &mut cb);
+    project.apply_changes(cb, &reg).unwrap();
+
+    assert_eq!(read_num(&project, &reg, main, data_id), 5);
+
+    project.switch_branch(main);
+    let mut cb = ChangeBuilder::from(&project);
+    cb.merge_branch(feature, main);
+    project.apply_changes(cb, &reg).unwrap();
+    assert_eq!(read_num(&project, &reg, main, data_id), 11);
+}
+
+#[test]
+fn undo_of_merge_branch_hides_imported_ops() {
+    let (mut project, reg) = fresh_project();
+    let main = project.current_branch();
+    let feature = BranchId::new();
+
+    let mut cb = ChangeBuilder::from(&project);
+    let view = project.create_view(&reg).unwrap();
+    let doc = *view.create_document(&mut cb, "/d".try_into().unwrap());
+    project.apply_changes(cb, &reg).unwrap();
+    let mut cb = ChangeBuilder::from(&project);
+    let view = project.create_view(&reg).unwrap();
+    let data_id = *view
+        .open_document(doc)
+        .unwrap()
+        .create_data::<MinimalTestModule>(&mut cb);
+    project.apply_changes(cb, &reg).unwrap();
+
+    // Fork: give feature visibility of main's current state.
+    let mut cb = ChangeBuilder::from(&project);
+    cb.merge_branch(main, feature);
+    project.apply_changes(cb, &reg).unwrap();
+
+    project.switch_branch(feature);
+    let mut cb = ChangeBuilder::from(&project);
+    let view = project.create_view(&reg).unwrap();
+    view.open_data_by_id::<MinimalTestModule>(data_id)
+        .unwrap()
+        .apply_persistent(9, &mut cb);
+    project.apply_changes(cb, &reg).unwrap();
+
+    // Reset session so undo targets only the merge, not the CreateDocument/CreateData setup.
+    project.switch_branch(main);
+    project.reset_session();
+    let mut cb = ChangeBuilder::from(&project);
+    cb.merge_branch(feature, main);
+    project.apply_changes(cb, &reg).unwrap();
+    assert_eq!(read_num(&project, &reg, main, data_id), 9);
+
+    let mut cb = ChangeBuilder::from(&project);
+    cb.undo();
+    project.apply_changes(cb, &reg).unwrap();
+    assert_eq!(read_num(&project, &reg, main, data_id), 0);
+
+    let mut cb = ChangeBuilder::from(&project);
+    cb.redo();
+    project.apply_changes(cb, &reg).unwrap();
+    assert_eq!(read_num(&project, &reg, main, data_id), 9);
+}

--- a/crates/project/tests/branching.rs
+++ b/crates/project/tests/branching.rs
@@ -203,3 +203,63 @@ fn undo_of_merge_branch_hides_imported_ops() {
     project.apply_changes(cb, &reg).unwrap();
     assert_eq!(read_num(&project, &reg, main, data_id), 9);
 }
+
+#[test]
+fn multi_hop_merge_respects_per_hop_snapshot_order() {
+    let (mut project, reg) = fresh_project();
+    let main = project.current_branch();
+    let feature = BranchId::new();
+    let hot = BranchId::new();
+
+    // Setup: one document with one data on main.
+    let mut cb = ChangeBuilder::from(&project);
+    let view = project.create_view(&reg).unwrap();
+    let doc = *view.create_document(&mut cb, "/d".try_into().unwrap());
+    project.apply_changes(cb, &reg).unwrap();
+
+    let mut cb = ChangeBuilder::from(&project);
+    let view = project.create_view(&reg).unwrap();
+    let data_id = *view
+        .open_document(doc)
+        .unwrap()
+        .create_data::<MinimalTestModule>(&mut cb);
+    project.apply_changes(cb, &reg).unwrap();
+
+    // Bring main's setup into feature and hot so each branch has the data.
+    project.switch_branch(feature);
+    let mut cb = ChangeBuilder::from(&project);
+    cb.merge_branch(main, feature);
+    project.apply_changes(cb, &reg).unwrap();
+
+    project.switch_branch(hot);
+    let mut cb = ChangeBuilder::from(&project);
+    cb.merge_branch(main, hot);
+    project.apply_changes(cb, &reg).unwrap();
+
+    // hot edits the data.
+    let mut cb = ChangeBuilder::from(&project);
+    let view = project.create_view(&reg).unwrap();
+    view.open_data_by_id::<MinimalTestModule>(data_id)
+        .unwrap()
+        .apply_persistent(42, &mut cb);
+    project.apply_changes(cb, &reg).unwrap();
+
+    // Merge feature -> main FIRST (feature has no edits from hot yet).
+    project.switch_branch(main);
+    let mut cb = ChangeBuilder::from(&project);
+    cb.merge_branch(feature, main);
+    project.apply_changes(cb, &reg).unwrap();
+
+    // Then merge hot -> feature (introducing hot's edit into feature).
+    project.switch_branch(feature);
+    let mut cb = ChangeBuilder::from(&project);
+    cb.merge_branch(hot, feature);
+    project.apply_changes(cb, &reg).unwrap();
+
+    // Main should still see the default value: hot's edit got into feature
+    // AFTER feature was merged into main, so main never absorbed it.
+    assert_eq!(read_num(&project, &reg, main, data_id), 0);
+
+    // Feature should see hot's edit, since hot was merged into feature last.
+    assert_eq!(read_num(&project, &reg, feature, data_id), 42);
+}

--- a/crates/project/tests/lamport_clock.rs
+++ b/crates/project/tests/lamport_clock.rs
@@ -1,0 +1,44 @@
+mod common;
+
+use common::*;
+use project::{ChangeBuilder, Project};
+
+/// Reach into the serialized log to inspect lamport values.
+///
+/// Round-trips the project through JSON to access the log shape
+/// without exposing internal fields.
+fn lamports_of(project: &Project) -> Vec<u64> {
+    let json = serde_json::to_value(project).expect("serialize project");
+    let log = json
+        .get("log")
+        .and_then(|v| v.as_array())
+        .expect("log is an array");
+    log.iter()
+        .map(|e| e.get("lamport").and_then(|v| v.as_u64()).unwrap())
+        .collect()
+}
+
+#[test]
+fn lamport_advances_on_local_apply() {
+    let mut reg = project::ModuleRegistry::new();
+    reg.register::<MinimalTestModule>();
+
+    let mut project = Project::new();
+    let view = project.create_view(&reg).unwrap();
+
+    let mut cb = ChangeBuilder::from(&project);
+    let _ = view.create_document(&mut cb, "/a".try_into().unwrap());
+    project.apply_changes(cb, &reg).unwrap();
+
+    let mut cb = ChangeBuilder::from(&project);
+    let view = project.create_view(&reg).unwrap();
+    let _ = view.create_document(&mut cb, "/b".try_into().unwrap());
+    project.apply_changes(cb, &reg).unwrap();
+
+    let lamports = lamports_of(&project);
+    // Expected entries in order:
+    //   NewSession (lamport 0)
+    //   Changes("/a" creation, lamport 1)
+    //   Changes("/b" creation, lamport 2)
+    assert_eq!(lamports, vec![0, 1, 2]);
+}

--- a/crates/project/tests/lamport_clock.rs
+++ b/crates/project/tests/lamport_clock.rs
@@ -79,3 +79,15 @@ fn merge_remote_advances_clock_past_max_remote_lamport() {
     let a_max = lamports_of(&a).into_iter().max().unwrap();
     assert!(a_max > b_max, "a_max={a_max} should exceed b_max={b_max}");
 }
+
+#[test]
+fn empty_change_builder_does_not_advance_clock_or_log() {
+    let mut reg = ModuleRegistry::new();
+    reg.register::<MinimalTestModule>();
+    let mut project = Project::new();
+
+    let cb = ChangeBuilder::from(&project);
+    project.apply_changes(cb, &reg).unwrap();
+
+    assert!(lamports_of(&project).is_empty());
+}

--- a/crates/project/tests/lamport_clock.rs
+++ b/crates/project/tests/lamport_clock.rs
@@ -1,7 +1,7 @@
 mod common;
 
 use common::*;
-use project::{ChangeBuilder, Project};
+use project::{ChangeBuilder, ModuleRegistry, Project};
 
 /// Reach into the serialized log to inspect lamport values.
 ///
@@ -41,4 +41,41 @@ fn lamport_advances_on_local_apply() {
     //   Changes("/a" creation, lamport 1)
     //   Changes("/b" creation, lamport 2)
     assert_eq!(lamports, vec![0, 1, 2]);
+}
+
+#[test]
+fn merge_remote_advances_clock_past_max_remote_lamport() {
+    let mut reg = ModuleRegistry::new();
+    reg.register::<MinimalTestModule>();
+    let mut a = Project::new();
+
+    let mut cb = ChangeBuilder::from(&a);
+    let view = a.create_view(&reg).unwrap();
+    let _doc = *view.create_document(&mut cb, "/d".try_into().unwrap());
+    a.apply_changes(cb, &reg).unwrap();
+
+    // Fork.
+    let mut b = a.clone_for_test_replica();
+
+    // B advances its clock by applying many local ops.
+    for i in 0..10 {
+        let mut cb = ChangeBuilder::from(&b);
+        let view = b.create_view(&reg).unwrap();
+        let _ = view.create_document(&mut cb, format!("/x{i}").as_str().try_into().unwrap());
+        b.apply_changes(cb, &reg).unwrap();
+    }
+
+    let b_max = lamports_of(&b).into_iter().max().unwrap();
+
+    // A merges B. A's clock should jump past B's max.
+    a.merge_remote(&b, &reg).unwrap();
+
+    // A's next local op must have lamport > b_max.
+    let mut cb = ChangeBuilder::from(&a);
+    let view = a.create_view(&reg).unwrap();
+    let _ = view.create_document(&mut cb, "/post-merge".try_into().unwrap());
+    a.apply_changes(cb, &reg).unwrap();
+
+    let a_max = lamports_of(&a).into_iter().max().unwrap();
+    assert!(a_max > b_max, "a_max={a_max} should exceed b_max={b_max}");
 }

--- a/crates/project/tests/lamport_clock.rs
+++ b/crates/project/tests/lamport_clock.rs
@@ -91,3 +91,15 @@ fn empty_change_builder_does_not_advance_clock_or_log() {
 
     assert!(lamports_of(&project).is_empty());
 }
+
+#[test]
+fn merge_empty_remote_does_not_advance_clock() {
+    let mut reg = ModuleRegistry::new();
+    reg.register::<MinimalTestModule>();
+    let mut a = Project::new();
+    let b = a.fork_replica(UserId::new());
+
+    a.merge_remote(&b, &reg).unwrap();
+
+    assert!(lamports_of(&a).is_empty());
+}

--- a/crates/project/tests/lamport_clock.rs
+++ b/crates/project/tests/lamport_clock.rs
@@ -1,7 +1,7 @@
 mod common;
 
 use common::*;
-use project::{ChangeBuilder, ModuleRegistry, Project};
+use project::{ChangeBuilder, ModuleRegistry, Project, UserId};
 
 /// Reach into the serialized log to inspect lamport values.
 ///
@@ -55,7 +55,7 @@ fn merge_remote_advances_clock_past_max_remote_lamport() {
     a.apply_changes(cb, &reg).unwrap();
 
     // Fork.
-    let mut b = a.clone_for_test_replica();
+    let mut b = a.fork_replica(UserId::new());
 
     // B advances its clock by applying many local ops.
     for i in 0..10 {

--- a/crates/project/tests/multi_user.rs
+++ b/crates/project/tests/multi_user.rs
@@ -107,9 +107,7 @@ fn session_a_undo_does_not_affect_session_b() {
     edit(&mut a, &reg, data_id, 5);
     edit(&mut b, &reg, data_id, 9);
 
-    let mut cb = ChangeBuilder::from(&a);
-    cb.undo();
-    a.apply_changes(cb, &reg).unwrap();
+    a.undo();
     assert_eq!(
         read(&a, &reg, data_id),
         0,

--- a/crates/project/tests/multi_user.rs
+++ b/crates/project/tests/multi_user.rs
@@ -1,7 +1,7 @@
 mod common;
 
 use common::*;
-use project::{ChangeBuilder, ModuleRegistry, Project};
+use project::{ChangeBuilder, ModuleRegistry, Project, UserId};
 
 fn setup() -> (Project, project::DataId, ModuleRegistry) {
     let mut reg = ModuleRegistry::new();
@@ -45,8 +45,8 @@ fn edit(p: &mut Project, reg: &ModuleRegistry, data_id: project::DataId, val: i3
 #[test]
 fn three_replicas_in_cycle_all_converge() {
     let (mut a, data_id, reg) = setup();
-    let mut b = a.clone_for_test_replica();
-    let mut c = a.clone_for_test_replica();
+    let mut b = a.fork_replica(UserId::new());
+    let mut c = a.fork_replica(UserId::new());
 
     edit(&mut a, &reg, data_id, 1);
     edit(&mut b, &reg, data_id, 2);
@@ -73,7 +73,7 @@ fn concurrent_edits_lww_by_lamport_session() {
     // otherwise b's mandatory NewSession bumps its edit's lamport above a's,
     // and the (lamport, session_id) tiebreaker never engages.
     a.reset_session();
-    let mut b = a.clone_for_test_replica();
+    let mut b = a.fork_replica(UserId::new());
 
     edit(&mut a, &reg, data_id, 100);
     edit(&mut b, &reg, data_id, 200);
@@ -102,7 +102,7 @@ fn concurrent_edits_lww_by_lamport_session() {
 #[test]
 fn session_a_undo_does_not_affect_session_b() {
     let (mut a, data_id, reg) = setup();
-    let mut b = a.clone_for_test_replica();
+    let mut b = a.fork_replica(UserId::new());
 
     edit(&mut a, &reg, data_id, 5);
     edit(&mut b, &reg, data_id, 9);

--- a/crates/project/tests/multi_user.rs
+++ b/crates/project/tests/multi_user.rs
@@ -1,0 +1,133 @@
+mod common;
+
+use common::*;
+use project::{ChangeBuilder, ModuleRegistry, Project};
+
+fn setup() -> (Project, project::DataId, ModuleRegistry) {
+    let mut reg = ModuleRegistry::new();
+    reg.register::<MinimalTestModule>();
+    let mut project = Project::new();
+
+    let mut cb = ChangeBuilder::from(&project);
+    let view = project.create_view(&reg).unwrap();
+    let doc = *view.create_document(&mut cb, "/d".try_into().unwrap());
+    project.apply_changes(cb, &reg).unwrap();
+
+    let mut cb = ChangeBuilder::from(&project);
+    let view = project.create_view(&reg).unwrap();
+    let data_id = *view
+        .open_document(doc)
+        .unwrap()
+        .create_data::<MinimalTestModule>(&mut cb);
+    project.apply_changes(cb, &reg).unwrap();
+
+    (project, data_id, reg)
+}
+
+fn read(p: &Project, reg: &ModuleRegistry, data_id: project::DataId) -> i32 {
+    p.create_view(reg)
+        .unwrap()
+        .open_data_by_id::<MinimalTestModule>(data_id)
+        .unwrap()
+        .persistent
+        .num
+}
+
+fn edit(p: &mut Project, reg: &ModuleRegistry, data_id: project::DataId, val: i32) {
+    let mut cb = ChangeBuilder::from(p);
+    let view = p.create_view(reg).unwrap();
+    view.open_data_by_id::<MinimalTestModule>(data_id)
+        .unwrap()
+        .apply_persistent(val, &mut cb);
+    p.apply_changes(cb, reg).unwrap();
+}
+
+#[test]
+fn three_replicas_in_cycle_all_converge() {
+    let (mut a, data_id, reg) = setup();
+    let mut b = a.clone_for_test_replica();
+    let mut c = a.clone_for_test_replica();
+
+    edit(&mut a, &reg, data_id, 1);
+    edit(&mut b, &reg, data_id, 2);
+    edit(&mut c, &reg, data_id, 3);
+
+    a.merge_remote(&b, &reg).unwrap();
+    b.merge_remote(&c, &reg).unwrap();
+    c.merge_remote(&a, &reg).unwrap();
+    a.merge_remote(&c, &reg).unwrap();
+    b.merge_remote(&a, &reg).unwrap();
+
+    let va = read(&a, &reg, data_id);
+    let vb = read(&b, &reg, data_id);
+    let vc = read(&c, &reg, data_id);
+    assert_eq!(va, vb);
+    assert_eq!(vb, vc);
+}
+
+#[test]
+fn concurrent_edits_lww_by_lamport_session() {
+    let (mut a, data_id, reg) = setup();
+
+    // Reset a's session so both replicas mint sessions concurrently;
+    // otherwise b's mandatory NewSession bumps its edit's lamport above a's,
+    // and the (lamport, session_id) tiebreaker never engages.
+    a.reset_session();
+    let mut b = a.clone_for_test_replica();
+
+    edit(&mut a, &reg, data_id, 100);
+    edit(&mut b, &reg, data_id, 200);
+
+    let a_session = a.current_session().expect("a has a session after edit");
+    let b_session = b.current_session().expect("b has a session after edit");
+
+    a.merge_remote(&b, &reg).unwrap();
+    b.merge_remote(&a, &reg).unwrap();
+
+    let va = read(&a, &reg, data_id);
+    let vb = read(&b, &reg, data_id);
+    assert_eq!(va, vb, "both replicas converge");
+    assert!(
+        va == 100 || va == 200,
+        "converged value must be one of the two edits"
+    );
+
+    let expected = if a_session > b_session { 100 } else { 200 };
+    assert_eq!(
+        va, expected,
+        "LWW winner determined by (lamport, session_id)"
+    );
+}
+
+#[test]
+fn session_a_undo_does_not_affect_session_b() {
+    let (mut a, data_id, reg) = setup();
+    let mut b = a.clone_for_test_replica();
+
+    edit(&mut a, &reg, data_id, 5);
+    edit(&mut b, &reg, data_id, 9);
+
+    let mut cb = ChangeBuilder::from(&a);
+    cb.undo();
+    a.apply_changes(cb, &reg).unwrap();
+    assert_eq!(
+        read(&a, &reg, data_id),
+        0,
+        "A's undo should revert its own edit"
+    );
+
+    a.merge_remote(&b, &reg).unwrap();
+    b.merge_remote(&a, &reg).unwrap();
+
+    // Both sides see B's value (A's was undone).
+    assert_eq!(read(&a, &reg, data_id), 9);
+    assert_eq!(read(&b, &reg, data_id), 9);
+}
+
+#[test]
+fn merge_different_project_rejected() {
+    let (mut a, _, reg) = setup();
+    let unrelated = Project::new();
+    let err = a.merge_remote(&unrelated, &reg).unwrap_err();
+    assert!(matches!(err, project::MergeError::DifferentProject));
+}

--- a/crates/project/tests/serde.rs
+++ b/crates/project/tests/serde.rs
@@ -108,3 +108,28 @@ fn project_with_undo_redo_mergebranch_round_trips() {
             .num,
     );
 }
+
+#[test]
+fn project_uuid_round_trips_through_serde() {
+    // The real observable property: a deserialized replica can be merged back
+    // into the original. merge_remote returns DifferentProject if the uuid
+    // didn't survive the round-trip.
+    let mut reg = ModuleRegistry::new();
+    reg.register::<MinimalTestModule>();
+    let mut project = Project::new();
+
+    let mut cb = ChangeBuilder::from(&project);
+    let view = project.create_view(&reg).unwrap();
+    let _ = view.create_document(&mut cb, "/d".try_into().unwrap());
+    project.apply_changes(cb, &reg).unwrap();
+
+    let json = serde_json::to_string(&project).unwrap();
+    let seed = ProjectDeserializer { registry: &reg };
+    let deserializer = &mut serde_json::Deserializer::from_str(&json);
+    let round_tripped = seed.deserialize(deserializer).unwrap();
+
+    let mut a = project;
+    let b = round_tripped;
+    a.merge_remote(&b, &reg)
+        .expect("uuids should match after serde round-trip");
+}

--- a/crates/project/tests/serde.rs
+++ b/crates/project/tests/serde.rs
@@ -60,3 +60,51 @@ fn test_deserialize_unknown_module_json() {
     let deserializer = &mut serde_json::Deserializer::from_str(&json);
     assert!(seed.deserialize(deserializer).is_err());
 }
+
+#[test]
+fn project_with_undo_redo_mergebranch_round_trips() {
+    let mut reg = ModuleRegistry::new();
+    reg.register::<MinimalTestModule>();
+    let mut project = Project::new();
+
+    let mut cb = ChangeBuilder::from(&project);
+    let view = project.create_view(&reg).unwrap();
+    let doc = *view.create_document(&mut cb, "/d".try_into().unwrap());
+    project.apply_changes(cb, &reg).unwrap();
+
+    let mut cb = ChangeBuilder::from(&project);
+    let view = project.create_view(&reg).unwrap();
+    let data_id = *view
+        .open_document(doc)
+        .unwrap()
+        .create_data::<MinimalTestModule>(&mut cb);
+    project.apply_changes(cb, &reg).unwrap();
+
+    let mut cb = ChangeBuilder::from(&project);
+    let view = project.create_view(&reg).unwrap();
+    view.open_data_by_id::<MinimalTestModule>(data_id)
+        .unwrap()
+        .apply_persistent(7, &mut cb);
+    cb.undo();
+    cb.redo();
+    cb.merge_branch(BranchId::new(), project.current_branch());
+    project.apply_changes(cb, &reg).unwrap();
+
+    let json = serde_json::to_string(&project).unwrap();
+    let seed = ProjectDeserializer { registry: &reg };
+    let deserializer = &mut serde_json::Deserializer::from_str(&json);
+    let round_tripped = seed.deserialize(deserializer).unwrap();
+
+    let a = project.create_view(&reg).unwrap();
+    let b = round_tripped.create_view(&reg).unwrap();
+    assert_eq!(
+        a.open_data_by_id::<MinimalTestModule>(data_id)
+            .unwrap()
+            .persistent
+            .num,
+        b.open_data_by_id::<MinimalTestModule>(data_id)
+            .unwrap()
+            .persistent
+            .num,
+    );
+}

--- a/crates/project/tests/serde.rs
+++ b/crates/project/tests/serde.rs
@@ -85,10 +85,10 @@ fn project_with_undo_redo_mergebranch_round_trips() {
     view.open_data_by_id::<MinimalTestModule>(data_id)
         .unwrap()
         .apply_persistent(7, &mut cb);
-    cb.undo();
-    cb.redo();
-    cb.merge_branch(BranchId::new(), project.current_branch());
     project.apply_changes(cb, &reg).unwrap();
+    project.undo();
+    project.redo();
+    project.merge_branch(BranchId::new(), project.current_branch());
 
     let json = serde_json::to_string(&project).unwrap();
     let seed = ProjectDeserializer { registry: &reg };

--- a/crates/project/tests/thread_safety.rs
+++ b/crates/project/tests/thread_safety.rs
@@ -22,4 +22,12 @@ fn test_send_sync() {
     assert_send_sync::<TrackedProjectView>();
     assert_send_sync::<TrackedDocumentView<'_>>();
     assert_send_sync::<TrackedDataView<'_, MinimalTestModule>>();
+
+    assert_send_sync::<MergeError>();
+    assert_send_sync::<LogEntry>();
+    assert_send_sync::<LogPayload>();
+    assert_send_sync::<Change>();
+    assert_send_sync::<BranchId>();
+    assert_send_sync::<SessionId>();
+    assert_send_sync::<CheckpointId>();
 }

--- a/crates/project/tests/time_travel.rs
+++ b/crates/project/tests/time_travel.rs
@@ -1,0 +1,75 @@
+mod common;
+
+use common::*;
+use project::{ChangeBuilder, ModuleRegistry, Project};
+
+#[test]
+fn create_view_at_returns_historical_state() {
+    let mut reg = ModuleRegistry::new();
+    reg.register::<MinimalTestModule>();
+    let mut project = Project::new();
+
+    let mut cb = ChangeBuilder::from(&project);
+    let view = project.create_view(&reg).unwrap();
+    let doc = *view.create_document(&mut cb, "/d".try_into().unwrap());
+    project.apply_changes(cb, &reg).unwrap();
+
+    let mut cb = ChangeBuilder::from(&project);
+    let view = project.create_view(&reg).unwrap();
+    let data_id = *view
+        .open_document(doc)
+        .unwrap()
+        .create_data::<MinimalTestModule>(&mut cb);
+    project.apply_changes(cb, &reg).unwrap();
+
+    // Edit a series of values; capture the lamport of each edit by inspecting
+    // the log post-apply.
+    let mut points: Vec<(i32, u64)> = Vec::new();
+    for v in [3, 7, 21] {
+        let mut cb = ChangeBuilder::from(&project);
+        let view = project.create_view(&reg).unwrap();
+        view.open_data_by_id::<MinimalTestModule>(data_id)
+            .unwrap()
+            .apply_persistent(v, &mut cb);
+        project.apply_changes(cb, &reg).unwrap();
+        let t = project_max_lamport(&project);
+        points.push((v, t));
+    }
+
+    // View at the lamport of each edit; expect that value.
+    let branch = project.current_branch();
+    for (v, t) in &points {
+        let view = project.create_view_at(&reg, branch, *t).unwrap();
+        let n = view
+            .open_data_by_id::<MinimalTestModule>(data_id)
+            .unwrap()
+            .persistent
+            .num;
+        assert_eq!(n, *v, "view at lamport {t} should see value {v}");
+    }
+
+    // Viewing at a lamport before the first edit but after setup gives default (0).
+    let pre_edit_lamport = points[0].1 - 1;
+    let view = project
+        .create_view_at(&reg, branch, pre_edit_lamport)
+        .unwrap();
+    assert_eq!(
+        view.open_data_by_id::<MinimalTestModule>(data_id)
+            .unwrap()
+            .persistent
+            .num,
+        0,
+        "view before any edits should see default"
+    );
+}
+
+fn project_max_lamport(p: &Project) -> u64 {
+    let json = serde_json::to_value(p).unwrap();
+    json.get("log")
+        .and_then(|v| v.as_array())
+        .unwrap()
+        .iter()
+        .map(|e| e.get("lamport").and_then(|x| x.as_u64()).unwrap())
+        .max()
+        .unwrap()
+}

--- a/crates/project/tests/undo_redo.rs
+++ b/crates/project/tests/undo_redo.rs
@@ -30,17 +30,18 @@ fn run_sequence(seq: &[i32]) -> i32 {
     project.reset_session();
 
     for &v in seq {
-        let mut cb = ChangeBuilder::from(&project);
-        let view = project.create_view(&reg).unwrap();
         match v {
-            0 => cb.undo(),
-            -1 => cb.redo(),
-            n => view
-                .open_data_by_id::<MinimalTestModule>(data_id)
-                .unwrap()
-                .apply_persistent(n, &mut cb),
+            0 => project.undo(),
+            -1 => project.redo(),
+            n => {
+                let mut cb = ChangeBuilder::from(&project);
+                let view = project.create_view(&reg).unwrap();
+                view.open_data_by_id::<MinimalTestModule>(data_id)
+                    .unwrap()
+                    .apply_persistent(n, &mut cb);
+                project.apply_changes(cb, &reg).unwrap();
+            }
         }
-        project.apply_changes(cb, &reg).unwrap();
     }
 
     let view = project.create_view(&reg).unwrap();

--- a/crates/project/tests/undo_redo.rs
+++ b/crates/project/tests/undo_redo.rs
@@ -1,730 +1,87 @@
-/*
-TODO: port this once undo/redo is implemented
 mod common;
-use common::test_module::*;
-use data::{DataUuid, DataView};
-use project::data::transaction::TransactionArgs;
-use project::*;
 
-fn create_undo_redo_test_setup() -> (
-    ProjectView,
-    DataView<TestModule>,
-    DataView<TestModule>,
-    DataUuid,
-    Vec<TestTransaction>,
-) {
-    let project = Project::new("Project".to_string()).create_view();
-    let doc = project.create_document();
-    let doc = project.open_document(doc).unwrap();
-    let data_uuid = doc.create_data::<TestModule>();
-
-    let mut session1 = doc.open_data_by_uuid::<TestModule>(data_uuid).unwrap();
-    let mut session2 = doc.open_data_by_uuid::<TestModule>(data_uuid).unwrap();
-
-    let transactions = vec![
-        (
-            1,
-            TransactionArgs::Persistent(TestTransaction::SetWord("word_a".to_string())),
-        ),
-        (
-            1,
-            TransactionArgs::PersistentUser(TestTransaction::SetWord("word_b".to_string())),
-        ),
-        (
-            2,
-            TransactionArgs::Persistent(TestTransaction::SetWord("word_c".to_string())),
-        ),
-        (
-            2,
-            TransactionArgs::PersistentUser(TestTransaction::SetWord("word_d".to_string())),
-        ),
-        (
-            1,
-            TransactionArgs::Persistent(TestTransaction::SetWord("word_e".to_string())),
-        ),
-    ];
-
-    // Apply transactions
-    for (session_number, transaction) in &transactions {
-        let session = match session_number {
-            1 => &mut session1,
-            2 => &mut session2,
-            _ => panic!("Invalid session number"),
-        };
-        assert!(session.apply(transaction.clone()).is_ok());
-    }
-
-    // Now we cast away unneeded information from the transactions list
-    let transactions = transactions
-        .into_iter()
-        .map(|(_, transaction)| match transaction {
-            TransactionArgs::Persistent(transaction) => transaction,
-            TransactionArgs::PersistentUser(transaction) => transaction,
-            TransactionArgs::Session(transaction) => transaction,
-            TransactionArgs::Shared(transaction) => transaction,
-        })
-        .collect();
-
-    // This will copy the internal logging id from the internal document
-    // to our sessions. This is needed to inspect the applied undo/apply
-    // transactions until we implement a non copy based distribution
-    // of the new state.
-    // TODO: Remove this when undo/redo doesn't copy
-    session1.redo(1);
-
-    let snapshot = session1.snapshot();
-    assert_eq!(snapshot.persistent.single_word, "word_e".to_string());
-    assert_eq!(snapshot.persistent_user.single_word, "word_d".to_string());
-
-    let (hist, loc) = session1.undo_redo_list();
-    assert_eq!(
-        hist,
-        vec![
-            "Set word to word_a".to_string(),
-            "Set word to word_b".to_string(),
-            "Set word to word_e".to_string(),
-        ]
-    );
-    assert_eq!(loc, 3);
-
-    let (hist, loc) = session2.undo_redo_list();
-    assert_eq!(
-        hist,
-        vec![
-            "Set word to word_c".to_string(),
-            "Set word to word_d".to_string(),
-        ]
-    );
-    assert_eq!(loc, 2);
-
-    (project, session1, session2, data_uuid, transactions)
-}
-
-#[test]
-fn test_undo_document_one_user() {
-    // Both session are owned by the same user
-    let (project, session1, session2, doc_uuid, transactions) = create_undo_redo_test_setup();
-    let session_doc_closure = project.open_data::<TestModule>(doc_uuid).unwrap();
-    let session_user_closure = project.open_data::<TestModule>(doc_uuid).unwrap();
-    // closures for getting a current snapshot of both data sections and the internal log
-    // Since all sessions are owned by the same user, the data should be the same
-    let document = || session_doc_closure.snapshot().persistent;
-    let user = || session_user_closure.snapshot().persistent_user;
-    let get_doc_log_and_clear = || {
-        let doc_log_uuid = document().logging_uuid;
-        let doc_log = get_transaction_log(doc_log_uuid);
-        clear_transaction_log(doc_log_uuid);
-        doc_log
-    };
-    let get_user_log_and_clear = || {
-        let user_log_uuid = user().logging_uuid;
-        let user_log = get_transaction_log(user_log_uuid);
-        clear_transaction_log(user_log_uuid);
-        user_log
-    };
-
-    // The internal undo stack for the document should look like this:
-    // (A is applied, U is undone, F is failed, Ar is applied but redone(undone+applied),
-    // Fr is failed but redone(undone+applied failed))
-    //
-    // 0. A - Doc(s1): SetWord("word_a")
-    // 1. A - User(s1): SetWord("word_b")
-    // 2. A - Doc(s2): SetWord("word_c")
-    // 3. A - User(s2): SetWord("word_d")
-    // 4. A - Doc(s1): SetWord("word_e")
-
-    get_doc_log_and_clear();
-    get_user_log_and_clear();
-    session2.undo(1);
-
-    // The internal undo stack now looks like this:
-    // 0. A - Doc(s1): SetWord("word_a")
-    // 1. A - User(s1): SetWord("word_b")
-    // 2. A - Doc(s2): SetWord("word_c")
-    // 3. U - User(s2): SetWord("word_d")
-    // 4. A - Doc(s1): SetWord("word_e")
-    assert_eq!(user().single_word, "word_b".to_string());
-    assert_eq!(document().single_word, "word_e".to_string());
-
-    let loc = session1.undo_redo_list().1;
-    assert_eq!(loc, 3);
-    let loc = session2.undo_redo_list().1;
-    assert_eq!(loc, 1);
-
-    assert_eq!(get_doc_log_and_clear(), vec![]);
-    assert_eq!(
-        get_user_log_and_clear(),
-        vec![(TransactionStatus::Undone, transactions[3].clone())]
-    );
-
-    session1.undo(2);
-
-    // The internal undo stack now looks like this:
-    // 0. A - Doc(s1): SetWord("word_a")
-    // 1. U - User(s1): SetWord("word_b")
-    // 2. A - Doc(s2): SetWord("word_c")
-    // 3. U - User(s2): SetWord("word_d")
-    // 4. U - Doc(s1): SetWord("word_e")
-    assert_eq!(user().single_word, "default".to_string());
-    assert_eq!(document().single_word, "word_c".to_string());
-
-    let loc = session1.undo_redo_list().1;
-    assert_eq!(loc, 1);
-    let loc = session2.undo_redo_list().1;
-    assert_eq!(loc, 1);
-
-    assert_eq!(
-        get_doc_log_and_clear(),
-        vec![(TransactionStatus::Undone, transactions[4].clone())]
-    );
-    assert_eq!(
-        get_user_log_and_clear(),
-        vec![(TransactionStatus::Undone, transactions[1].clone())]
-    );
-
-    // this should not change anything
-    session1.undo(0);
-    session2.undo(0);
-    assert_eq!(user().single_word, "default".to_string());
-    assert_eq!(document().single_word, "word_c".to_string());
-
-    let loc = session1.undo_redo_list().1;
-    assert_eq!(loc, 1);
-    let loc = session2.undo_redo_list().1;
-    assert_eq!(loc, 1);
-
-    session2.undo(1);
-
-    // The internal undo stack now looks like this:
-    // 0. A - Doc(s1): SetWord("word_a")
-    // 1. U - User(s1): SetWord("word_b")
-    // 2. U - Doc(s2): SetWord("word_c")
-    // 3. U - User(s2): SetWord("word_d")
-    // 4. U - Doc(s1): SetWord("word_e")
-    assert_eq!(user().single_word, "default".to_string());
-    assert_eq!(document().single_word, "word_a".to_string());
-
-    let loc = session1.undo_redo_list().1;
-    assert_eq!(loc, 1);
-    let loc = session2.undo_redo_list().1;
-    assert_eq!(loc, 0);
-
-    assert_eq!(
-        get_doc_log_and_clear(),
-        vec![(TransactionStatus::Undone, transactions[2].clone())]
-    );
-    assert_eq!(get_user_log_and_clear(), vec![]);
-
-    // And request 10 undo steps on session 1, should only undo 1
-    session1.undo(10);
-
-    // The internal undo stack now looks like this:
-    // 0. U - Doc(s1): SetWord("word_a")
-    // 1. U - User(s1): SetWord("word_b")
-    // 2. U - Doc(s2): SetWord("word_c")
-    // 3. U - User(s2): SetWord("word_d")
-    // 4. U - Doc(s1): SetWord("word_e")
-    assert_eq!(user().single_word, "default".to_string());
-    assert_eq!(document().single_word, "default".to_string());
-
-    let loc = session1.undo_redo_list().1;
-    assert_eq!(loc, 0);
-    let loc = session2.undo_redo_list().1;
-    assert_eq!(loc, 0);
-
-    assert_eq!(
-        get_doc_log_and_clear(),
-        vec![(TransactionStatus::Undone, transactions[0].clone())]
-    );
-    assert_eq!(get_user_log_and_clear(), vec![]);
-
-    // Try undoing 1 step on session 2, should do nothing
-    session1.undo(1);
-
-    assert_eq!(user().single_word, "default".to_string());
-    assert_eq!(document().single_word, "default".to_string());
-
-    let loc = session1.undo_redo_list().1;
-    assert_eq!(loc, 0);
-    let loc = session2.undo_redo_list().1;
-    assert_eq!(loc, 0);
-
-    assert_eq!(get_doc_log_and_clear(), vec![]);
-    assert_eq!(get_user_log_and_clear(), vec![]);
-}
-
-#[test]
-fn test_redo_document_one_user() {
-    // Both session are owned by the same user
-    let (project, session1, session2, doc_uuid, transactions) = create_undo_redo_test_setup();
-    let session_doc_closure = project.open_data::<TestModule>(doc_uuid).unwrap();
-    let session_user_closure = project.open_data::<TestModule>(doc_uuid).unwrap();
-    // closures for getting a current snapshot of both data sections and the internal log
-    // Since all sessions are owned by the same user, the data should be the same
-    let document = || session_doc_closure.snapshot().persistent;
-    let user = || session_user_closure.snapshot().persistent_user;
-    let get_doc_log_and_clear = || {
-        let doc_log_uuid = document().logging_uuid;
-        let doc_log = get_transaction_log(doc_log_uuid);
-        clear_transaction_log(doc_log_uuid);
-        doc_log
-    };
-    let get_user_log_and_clear = || {
-        let user_log_uuid = user().logging_uuid;
-        let user_log = get_transaction_log(user_log_uuid);
-        clear_transaction_log(user_log_uuid);
-        user_log
-    };
-
-    session1.undo(10);
-    session2.undo(10);
-
-    // The internal undo stack now looks like this:
-    // (A is applied, U is undone, F is failed, Ar is applied but redone(undone+applied),
-    // Fr is failed but redone(undone+applied failed))
-    //
-    // 0. U - Doc(s1): SetWord("word_a")
-    // 1. U - User(s1): SetWord("word_b")
-    // 2. U - Doc(s2): SetWord("word_c")
-    // 3. U - User(s2): SetWord("word_d")
-    // 4. U - Doc(s1): SetWord("word_e")
-    assert_eq!(user().single_word, "default".to_string());
-    assert_eq!(document().single_word, "default".to_string());
-
-    let loc = session1.undo_redo_list().1;
-    assert_eq!(loc, 0);
-    let loc = session2.undo_redo_list().1;
-    assert_eq!(loc, 0);
-
-    // We already tested undo, so we can assume that this log is correct
-    get_doc_log_and_clear();
-    get_user_log_and_clear();
-
-    // Should only redo as much as possible
-    session1.redo(10);
-
-    // The internal undo stack now looks like this:
-    // 0. A - Doc(s1): SetWord("word_a")
-    // 1. A - User(s1): SetWord("word_b")
-    // 2. U - Doc(s2): SetWord("word_c")
-    // 3. U - User(s2): SetWord("word_d")
-    // 4. A - Doc(s1): SetWord("word_e")
-
-    assert_eq!(user().single_word, "word_b".to_string());
-    assert_eq!(document().single_word, "word_e".to_string());
-
-    let loc = session1.undo_redo_list().1;
-    assert_eq!(loc, 3);
-    let loc = session2.undo_redo_list().1;
-    assert_eq!(loc, 0);
-
-    assert_eq!(
-        get_doc_log_and_clear(),
-        vec![
-            (TransactionStatus::Applied, transactions[0].clone()),
-            (TransactionStatus::Applied, transactions[4].clone()),
-        ]
-    );
-    assert_eq!(
-        get_user_log_and_clear(),
-        vec![(TransactionStatus::Applied, transactions[1].clone())]
-    );
-
-    session2.redo(1);
-
-    // The internal undo stack now looks like this:
-    // 0. A - Doc(s1): SetWord("word_a")
-    // 1. A - User(s1): SetWord("word_b")
-    // 2. A - Doc(s2): SetWord("word_c")
-    // 3. U - User(s2): SetWord("word_d")
-    // 4. Ar- Doc(s1): SetWord("word_e")
-
-    assert_eq!(user().single_word, "word_b".to_string());
-    assert_eq!(document().single_word, "word_e".to_string());
-
-    let loc = session1.undo_redo_list().1;
-    assert_eq!(loc, 3);
-    let loc = session2.undo_redo_list().1;
-    assert_eq!(loc, 1);
-
-    assert_eq!(
-        get_doc_log_and_clear(),
-        vec![
-            (TransactionStatus::Undone, transactions[4].clone()),
-            (TransactionStatus::Applied, transactions[2].clone()),
-            (TransactionStatus::Applied, transactions[4].clone())
-        ]
-    );
-    assert_eq!(get_user_log_and_clear(), vec![]);
-
-    session1.undo(1);
-
-    // The internal undo stack now looks like this:
-    // 0. A - Doc(s1): SetWord("word_a")
-    // 1. A - User(s1): SetWord("word_b")
-    // 2. A - Doc(s2): SetWord("word_c")
-    // 3. U - User(s2): SetWord("word_d")
-    // 4. U - Doc(s1): SetWord("word_e")
-
-    assert_eq!(user().single_word, "word_b".to_string());
-    assert_eq!(document().single_word, "word_c".to_string());
-
-    let loc = session1.undo_redo_list().1;
-    assert_eq!(loc, 2);
-    let loc = session2.undo_redo_list().1;
-    assert_eq!(loc, 1);
-
-    assert_eq!(
-        get_doc_log_and_clear(),
-        vec![(TransactionStatus::Undone, transactions[4].clone()),]
-    );
-    assert_eq!(get_user_log_and_clear(), vec![]);
-
-    // This should not change anything
-    session2.redo(0);
-    session1.redo(0);
-
-    assert_eq!(user().single_word, "word_b".to_string());
-    assert_eq!(document().single_word, "word_c".to_string());
-
-    let loc = session1.undo_redo_list().1;
-    assert_eq!(loc, 2);
-    let loc = session2.undo_redo_list().1;
-    assert_eq!(loc, 1);
-
-    assert_eq!(get_doc_log_and_clear(), vec![]);
-    assert_eq!(get_user_log_and_clear(), vec![]);
-
-    session1.undo(2);
-    // The internal undo stack now looks like this:
-    // 0. U - Doc(s1): SetWord("word_a")
-    // 1. U - User(s1): SetWord("word_b")
-    // 2. Ar - Doc(s2): SetWord("word_c")
-    // 3. U - User(s2): SetWord("word_d")
-    // 4. U - Doc(s1): SetWord("word_e")
-
-    assert_eq!(user().single_word, "default".to_string());
-    assert_eq!(document().single_word, "word_c".to_string());
-
-    let loc = session1.undo_redo_list().1;
-    assert_eq!(loc, 0);
-    let loc = session2.undo_redo_list().1;
-    assert_eq!(loc, 1);
-
-    assert_eq!(
-        get_doc_log_and_clear(),
-        vec![
-            (TransactionStatus::Undone, transactions[2].clone()),
-            (TransactionStatus::Undone, transactions[0].clone()),
-            (TransactionStatus::Applied, transactions[2].clone()),
-        ]
-    );
-    assert_eq!(
-        get_user_log_and_clear(),
-        vec![(TransactionStatus::Undone, transactions[1].clone()),]
-    );
-
-    session2.redo(1);
-    // The internal undo stack now looks like this:
-    // 0. U - Doc(s1): SetWord("word_a")
-    // 1. U - User(s1): SetWord("word_b")
-    // 2. A - Doc(s2): SetWord("word_c")
-    // 3. A - User(s2): SetWord("word_d")
-    // 4. U - Doc(s1): SetWord("word_e")
-
-    assert_eq!(user().single_word, "word_d".to_string());
-    assert_eq!(document().single_word, "word_c".to_string());
-
-    let loc = session1.undo_redo_list().1;
-    assert_eq!(loc, 0);
-    let loc = session2.undo_redo_list().1;
-    assert_eq!(loc, 2);
-
-    assert_eq!(get_doc_log_and_clear(), vec![]);
-    assert_eq!(
-        get_user_log_and_clear(),
-        vec![(TransactionStatus::Applied, transactions[3].clone()),]
-    );
-
-    session1.redo(1);
-    // The internal undo stack now looks like this:
-    // 0. A - Doc(s1): SetWord("word_a")
-    // 1. U - User(s1): SetWord("word_b")
-    // 2. Ar- Doc(s2): SetWord("word_c")
-    // 3. A - User(s2): SetWord("word_d")
-    // 4. U - Doc(s1): SetWord("word_e")
-
-    assert_eq!(user().single_word, "word_d".to_string());
-    assert_eq!(document().single_word, "word_c".to_string());
-
-    let loc = session1.undo_redo_list().1;
-    assert_eq!(loc, 1);
-    let loc = session2.undo_redo_list().1;
-    assert_eq!(loc, 2);
-
-    assert_eq!(
-        get_doc_log_and_clear(),
-        vec![
-            (TransactionStatus::Undone, transactions[2].clone()),
-            (TransactionStatus::Applied, transactions[0].clone()),
-            (TransactionStatus::Applied, transactions[2].clone()),
-        ]
-    );
-    assert_eq!(get_user_log_and_clear(), vec![]);
-}
-
-#[test]
-fn test_undo_redo_on_failed_transactions() {
-    let project = Project::new("Project".to_string()).create_view();
-    let doc_uuid = project.create_document();
-    let data_uuid = project
-        .open_document(doc_uuid)
+use common::*;
+use project::{ChangeBuilder, ModuleRegistry, Project};
+
+/// Build a project with one document, one MinimalTestModule data, and apply a
+/// sequence of integer-setting transactions to its persistent data, with the
+/// special markers 0 (Undo) and -1 (Redo).
+fn run_sequence(seq: &[i32]) -> i32 {
+    let mut reg = ModuleRegistry::new();
+    reg.register::<MinimalTestModule>();
+
+    let mut project = Project::new();
+
+    let mut cb = ChangeBuilder::from(&project);
+    let view = project.create_view(&reg).unwrap();
+    let doc = *view.create_document(&mut cb, "/d".try_into().unwrap());
+    project.apply_changes(cb, &reg).unwrap();
+
+    let mut cb = ChangeBuilder::from(&project);
+    let view = project.create_view(&reg).unwrap();
+    let data_id = *view
+        .open_document(doc)
         .unwrap()
-        .create_data::<TestModule>();
+        .create_data::<MinimalTestModule>(&mut cb);
+    project.apply_changes(cb, &reg).unwrap();
 
-    let mut session2 = project.open_data::<TestModule>(data_uuid).unwrap();
-    let mut session3 = project.open_data::<TestModule>(data_uuid).unwrap();
-    let mut session1 = project.open_data::<TestModule>(data_uuid).unwrap();
+    // Start a fresh session so that undo/redo in the sequence below cannot
+    // target the structural setup changes (CreateDocument, CreateData).
+    project.reset_session();
 
-    let transactions = vec![
-        (
-            1,
-            TransactionArgs::Persistent(TestTransaction::SetNumber(101)),
-        ),
-        (
-            1,
-            TransactionArgs::PersistentUser(TestTransaction::SetNumber(201)),
-        ),
-        (
-            1,
-            TransactionArgs::PersistentUser(TestTransaction::SetNumber(51)),
-        ),
-        (
-            2,
-            TransactionArgs::Persistent(TestTransaction::SetNumber(301)),
-        ),
-        (
-            3,
-            TransactionArgs::PersistentUser(TestTransaction::FailIfNumberIsOver100),
-        ),
-        (
-            2,
-            TransactionArgs::Persistent(TestTransaction::SetNumber(1)),
-        ),
-        (
-            3,
-            TransactionArgs::Persistent(TestTransaction::FailIfNumberIsOver100),
-        ),
-    ];
-
-    // Apply transactions
-    for (session_number, transaction) in &transactions {
-        let session = match session_number {
-            1 => &mut session1,
-            2 => &mut session2,
-            3 => &mut session3,
-            _ => panic!("Invalid session number"),
-        };
-        assert!(session.apply(transaction.clone()).is_ok());
+    for &v in seq {
+        let mut cb = ChangeBuilder::from(&project);
+        let view = project.create_view(&reg).unwrap();
+        match v {
+            0 => cb.undo(),
+            -1 => cb.redo(),
+            n => view
+                .open_data_by_id::<MinimalTestModule>(data_id)
+                .unwrap()
+                .apply_persistent(n, &mut cb),
+        }
+        project.apply_changes(cb, &reg).unwrap();
     }
 
-    // Now we cast away unneeded information from the transactions list
-    let transactions: Vec<TestTransaction> = transactions
-        .into_iter()
-        .map(|(_, transaction)| match transaction {
-            TransactionArgs::Persistent(transaction) => transaction,
-            TransactionArgs::PersistentUser(transaction) => transaction,
-            TransactionArgs::Session(transaction) => transaction,
-            TransactionArgs::Shared(transaction) => transaction,
-        })
-        .collect();
-
-    // This will copy the internal logging id from the internal document
-    // to our sessions. This is needed to inspect the applied undo/apply
-    // transactions until we implement a non copy based distribution
-    // of the new state.
-    // TODO: Remove this when undo/redo doesn't copy
-    session2.redo(1);
-
-    // We already tested the undo_redo_list in the previous tests
-
-    let session_doc_closure = project.open_data::<TestModule>(data_uuid).unwrap();
-    let session_user_closure = project.open_data::<TestModule>(data_uuid).unwrap();
-    // closures for getting a current snapshot of both data sections and the internal log
-    // Since all sessions are owned by the same user, the data should be the same
-    let document = || session_doc_closure.snapshot().persistent;
-    let user = || session_user_closure.snapshot().persistent_user;
-    let get_doc_log_and_clear = || {
-        let doc_log_uuid = document().logging_uuid;
-        let doc_log = get_transaction_log(doc_log_uuid);
-        clear_transaction_log(doc_log_uuid);
-        doc_log
-    };
-    let get_user_log_and_clear = || {
-        let user_log_uuid = user().logging_uuid;
-        let user_log = get_transaction_log(user_log_uuid);
-        clear_transaction_log(user_log_uuid);
-        user_log
-    };
-
-    // Now we test if the undo/redo works as expected on failed transactions
-
-    // The internal undo stack now looks like this:
-    // (A is applied, U is undone, F is failed, Ar is applied but redone(undone+applied),
-    // Fr is failed but redone(undone+applied failed))
-    //
-    // 0. A - Doc(s1): SetNumber(101)
-    // 1. A - User(s1): SetNumber(201)
-    // 2. A - User(s1): SetNumber(51)
-    // 3. A - Doc(s2): SetNumber(301)
-    // 4. A - User(s3): FailIfNumberIsOver100
-    // 5. A - Doc(s2): SetNumber(1)
-    // 6. A - Doc(s3): FailIfNumberIsOver100
-
-    get_doc_log_and_clear();
-    get_user_log_and_clear();
-
-    session1.undo(1);
-    // The internal undo stack now looks like this:
-    // 0. A - Doc(s1): SetNumber(101)
-    // 1. A - User(s1): SetNumber(201)
-    // 2. U - User(s1): SetNumber(51)
-    // 3. A - Doc(s2): SetNumber(301)
-    // 4. Fr- User(s3): FailIfNumberIsOver100
-    // 5. A - Doc(s2): SetNumber(1)
-    // 6. A - Doc(s3): FailIfNumberIsOver100
-
-    assert_eq!(get_doc_log_and_clear(), vec![]);
-    assert_eq!(
-        get_user_log_and_clear(),
-        vec![
-            (TransactionStatus::Undone, transactions[4].clone()),
-            (TransactionStatus::Undone, transactions[2].clone()),
-            (TransactionStatus::ApplyFailed, transactions[4].clone()),
-        ]
-    );
-
-    session2.undo(2);
-    // The internal undo stack now looks like this:
-    // 0. A - Doc(s1): SetNumber(101)
-    // 1. A - User(s1): SetNumber(201)
-    // 2. U - User(s1): SetNumber(51)
-    // 3. U - Doc(s2): SetNumber(301)
-    // 4. F - User(s3): FailIfNumberIsOver100
-    // 5. U - Doc(s2): SetNumber(1)
-    // 6. Fr- Doc(s3): FailIfNumberIsOver100
-    assert_eq!(
-        get_doc_log_and_clear(),
-        vec![
-            (TransactionStatus::Undone, transactions[6].clone()),
-            (TransactionStatus::Undone, transactions[5].clone()),
-            (TransactionStatus::Undone, transactions[3].clone()),
-            (TransactionStatus::ApplyFailed, transactions[6].clone()),
-        ]
-    );
-    assert_eq!(get_user_log_and_clear(), vec![]);
-
-    session2.redo(1);
-    // The internal undo stack now looks like this:
-    // 0. A - Doc(s1): SetNumber(101)
-    // 1. A - User(s1): SetNumber(201)
-    // 2. U - User(s1): SetNumber(51)
-    // 3. A - Doc(s2): SetNumber(301)
-    // 4. F - User(s3): FailIfNumberIsOver100
-    // 5. U - Doc(s2): SetNumber(1)
-    // 6. Fr- Doc(s3): FailIfNumberIsOver100
-    assert_eq!(
-        get_doc_log_and_clear(),
-        vec![
-            (TransactionStatus::Applied, transactions[3].clone()),
-            (TransactionStatus::ApplyFailed, transactions[6].clone()),
-        ]
-    );
-    assert_eq!(get_user_log_and_clear(), vec![]);
-
-    session1.undo(1);
-    // The internal undo stack now looks like this:
-    // 0. A - Doc(s1): SetNumber(101)
-    // 1. U - User(s1): SetNumber(201)
-    // 2. U - User(s1): SetNumber(51)
-    // 3. A - Doc(s2): SetNumber(301)
-    // 4. Ar- User(s3): FailIfNumberIsOver100
-    // 5. U - Doc(s2): SetNumber(1)
-    // 6. F - Doc(s3): FailIfNumberIsOver100
-    assert_eq!(get_doc_log_and_clear(), vec![]);
-    assert_eq!(
-        get_user_log_and_clear(),
-        vec![
-            (TransactionStatus::Undone, transactions[1].clone()),
-            (TransactionStatus::Applied, transactions[4].clone()),
-        ]
-    );
-
-    session1.redo(2);
-    // The internal undo stack now looks like this:
-    // 0. A - Doc(s1): SetNumber(101)
-    // 1. A - User(s1): SetNumber(201)
-    // 2. A - User(s1): SetNumber(51)
-    // 3. A - Doc(s2): SetNumber(301)
-    // 4. Ar- User(s3): FailIfNumberIsOver100
-    // 5. U - Doc(s2): SetNumber(1)
-    // 6. F - Doc(s3): FailIfNumberIsOver100
-    assert_eq!(get_doc_log_and_clear(), vec![]);
-    assert_eq!(
-        get_user_log_and_clear(),
-        vec![
-            (TransactionStatus::Undone, transactions[4].clone()),
-            (TransactionStatus::Applied, transactions[1].clone()),
-            (TransactionStatus::Applied, transactions[2].clone()),
-            (TransactionStatus::Applied, transactions[4].clone()),
-        ]
-    );
-
-    session3.undo(1);
-    // This should only mark the transaction as undone, but otherwise do nothing
-    // The internal undo stack now looks like this:
-    // 0. A - Doc(s1): SetNumber(101)
-    // 1. A - User(s1): SetNumber(201)
-    // 2. A - User(s1): SetNumber(51)
-    // 3. A - Doc(s2): SetNumber(301)
-    // 4. A - User(s3): FailIfNumberIsOver100
-    // 5. U - Doc(s2): SetNumber(1)
-    // 6. U - Doc(s3): FailIfNumberIsOver100
-    assert_eq!(get_doc_log_and_clear(), vec![]);
-    assert_eq!(get_user_log_and_clear(), vec![]);
-
-    session3.redo(1);
-    // This should try to apply the transaction again, but fail again
-    // The internal undo stack now looks like this:
-    // 0. A - Doc(s1): SetNumber(101)
-    // 1. A - User(s1): SetNumber(201)
-    // 2. A - User(s1): SetNumber(51)
-    // 3. A - Doc(s2): SetNumber(301)
-    // 4. A - User(s3): FailIfNumberIsOver100
-    // 5. U - Doc(s2): SetNumber(1)
-    // 6. F - Doc(s3): FailIfNumberIsOver100
-    assert_eq!(
-        get_doc_log_and_clear(),
-        vec![(TransactionStatus::ApplyFailed, transactions[6].clone())]
-    );
-    assert_eq!(get_user_log_and_clear(), vec![]);
-
-    session2.undo(1);
-    // The internal undo stack now looks like this:
-    // 0. A - Doc(s1): SetNumber(101)
-    // 1. A - User(s1): SetNumber(201)
-    // 2. A - User(s1): SetNumber(51)
-    // 3. U - Doc(s2): SetNumber(301)
-    // 4. A - User(s3): FailIfNumberIsOver100
-    // 5. U - Doc(s2): SetNumber(1)
-    // 6. Fr- Doc(s3): FailIfNumberIsOver100
-    assert_eq!(
-        get_doc_log_and_clear(),
-        vec![
-            (TransactionStatus::Undone, transactions[3].clone()),
-            (TransactionStatus::ApplyFailed, transactions[6].clone())
-        ]
-    );
-    assert_eq!(get_user_log_and_clear(), vec![]);
+    let view = project.create_view(&reg).unwrap();
+    view.open_data_by_id::<MinimalTestModule>(data_id)
+        .unwrap()
+        .persistent
+        .num
 }
-*/
+
+#[test]
+fn trace_simple_undo_after_two_edits() {
+    // [x6=6, x7=7, x8=8, Undo, x15=15] -> active includes x6, x7, x15 (x8 undone).
+    // LWW per-field: lamport-ordered apply gives final num = 15.
+    assert_eq!(run_sequence(&[6, 7, 8, 0, 15]), 15);
+}
+
+#[test]
+fn trace_three_undos_after_branchy_history() {
+    // [x6, x7, x8, Undo, x15, Undo, Undo] -> active = {x6}
+    assert_eq!(run_sequence(&[6, 7, 8, 0, 15, 0, 0]), 6);
+}
+
+#[test]
+fn trace_redo_after_new_edit_brings_back_undone() {
+    // [x6, Undo, x7, Redo] -> active {x6, x7}; LWW winner by lamport is x7.
+    assert_eq!(run_sequence(&[6, 0, 7, -1]), 7);
+}
+
+#[test]
+fn trace_undo_after_redo_targets_max_active() {
+    // [x6, Undo, x7, Redo, Undo] -> active {x6}; state [x6].
+    assert_eq!(run_sequence(&[6, 0, 7, -1, 0]), 6);
+}
+
+#[test]
+fn undo_on_empty_active_is_noop() {
+    // Just an Undo on a fresh data; no edits to cancel. Expect default (0).
+    assert_eq!(run_sequence(&[0]), 0);
+}
+
+#[test]
+fn redo_on_empty_buffer_is_noop() {
+    assert_eq!(run_sequence(&[5, -1]), 5);
+}


### PR DESCRIPTION
Implements a CRDT operation log for the `project` crate, replacing the flat `Vec<ProjectLogEntry>` with a `Vec<LogEntry>` totally ordered by `(lamport, session_id)`, so two replicas converge to the same state regardless of merge order. Adds undo and redo scoped per session, snapshot import semantics for `MergeBranch`, and `Project::merge_remote` for convergence between replicas. `Project::uuid` now serializes, so saved projects keep their identity across reloads and can merge with other replicas of themselves.

New public API on `Project`: `create_view_at`, `switch_branch`, `merge_remote`, `fork_replica`, `undo`, `redo`, `merge_branch`.

Closes #45.