### PR TITLE
feat(wasm-libc,occara): enable C++ exceptions on wasm and make fillet fallible

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-latest, windows-2022]
         toolchain: [stable]
     runs-on: ${{ matrix.os }}
     continue-on-error: ${{ matrix.toolchain == 'nightly' }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -74,17 +74,16 @@ jobs:
             ~/.cargo/git/db/
             target/*
             !target/opencascade-sys
-          key: cargo-wasm-${{ runner.os }}-${{ hashFiles('**/Cargo.lock') }}
+            !target/wasm-libcxx
+          key: cargo-wasm-v2-${{ runner.os }}-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
-            cargo-wasm-${{ runner.os }}-
+            cargo-wasm-v2-${{ runner.os }}-
       - name: Cache OpenCASCADE
         uses: actions/cache@v5
         with:
           path: |
             target/opencascade-sys/
-          key: occt-wasm-${{ runner.os }}-${{ hashFiles('crates/opencascade-sys/**') }}
-          restore-keys: |
-            occt-wasm-${{ runner.os }}-
+          key: occt-wasm-v2-${{ runner.os }}-${{ hashFiles('crates/opencascade-sys/**') }}
       - name: Install LLVM 22
         run: |
           wget https://apt.llvm.org/llvm.sh

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -85,5 +85,14 @@ jobs:
           key: occt-wasm-${{ runner.os }}-${{ hashFiles('crates/opencascade-sys/**') }}
           restore-keys: |
             occt-wasm-${{ runner.os }}-
+      - name: Install LLVM 22
+        run: |
+          wget https://apt.llvm.org/llvm.sh
+          chmod +x llvm.sh
+          sudo ./llvm.sh 22 all
       - name: Run WASM tests
+        env:
+          CC_wasm32_unknown_unknown: clang-22
+          CXX_wasm32_unknown_unknown: clang++-22
+          AR_wasm32_unknown_unknown: llvm-ar-22
         run: cargo make test-wasm

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2617,6 +2617,7 @@ dependencies = [
  "cxx-build",
  "miette",
  "opencascade-sys",
+ "thiserror 2.0.18",
  "walkdir",
  "wasm-bindgen-test",
  "wasm-libc",

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -175,6 +175,7 @@ script_runner = "@shell"
 script = '''
 WASM32_UNKNOWN_UNKNOWN_STDLIB_DIR="$(pwd)/target/wasm-libcxx/wasm32-unknown-unknown-libcxx" # shell2batch:
 . $WASM32_UNKNOWN_UNKNOWN_STDLIB_DIR/env.sh # shell2batch: call target\wasm-libcxx\wasm32-unknown-unknown-libcxx\env.bat
+if [ -z "$CC_wasm32_unknown_unknown" ]; then for cc in "$WASM_CC" /opt/homebrew/opt/llvm/bin/clang /usr/local/opt/llvm/bin/clang clang; do if [ -n "$cc" ] && command -v "$cc" >/dev/null 2>&1 && "$cc" -print-targets 2>/dev/null | grep -q wasm32; then ar_dir="$(dirname "$(command -v "$cc")")"; ar="$ar_dir/llvm-ar"; [ -x "$ar" ] || ar="llvm-ar"; export CC_wasm32_unknown_unknown="$cc" CXX_wasm32_unknown_unknown="${cc}++" AR_wasm32_unknown_unknown="$ar"; echo "Using wasm clang: $cc"; break; fi; done; fi # shell2batch:
 cd crates/cadara
 rustup run nightly wasm-pack build --target web --no-typescript --dev
 '''
@@ -200,6 +201,7 @@ script_runner = "@shell"
 script = '''
 WASM32_UNKNOWN_UNKNOWN_STDLIB_DIR="$(pwd)/target/wasm-libcxx/wasm32-unknown-unknown-libcxx" # shell2batch:
 . $WASM32_UNKNOWN_UNKNOWN_STDLIB_DIR/env.sh # shell2batch: call target\wasm-libcxx\wasm32-unknown-unknown-libcxx\env.bat
+if [ -z "$CC_wasm32_unknown_unknown" ]; then for cc in "$WASM_CC" /opt/homebrew/opt/llvm/bin/clang /usr/local/opt/llvm/bin/clang clang; do if [ -n "$cc" ] && command -v "$cc" >/dev/null 2>&1 && "$cc" -print-targets 2>/dev/null | grep -q wasm32; then ar_dir="$(dirname "$(command -v "$cc")")"; ar="$ar_dir/llvm-ar"; [ -x "$ar" ] || ar="llvm-ar"; export CC_wasm32_unknown_unknown="$cc" CXX_wasm32_unknown_unknown="${cc}++" AR_wasm32_unknown_unknown="$ar"; echo "Using wasm clang: $cc"; break; fi; done; fi # shell2batch:
 cd crates/cadara
 rustup run nightly wasm-pack build --target web --no-typescript
 '''
@@ -235,6 +237,7 @@ script_runner = "@shell"
 script = '''
 WASM32_UNKNOWN_UNKNOWN_STDLIB_DIR="$(pwd)/target/wasm-libcxx/wasm32-unknown-unknown-libcxx" # shell2batch:
 . $WASM32_UNKNOWN_UNKNOWN_STDLIB_DIR/env.sh # shell2batch: call target\wasm-libcxx\wasm32-unknown-unknown-libcxx\env.bat
+if [ -z "$CC_wasm32_unknown_unknown" ]; then for cc in "$WASM_CC" /opt/homebrew/opt/llvm/bin/clang /usr/local/opt/llvm/bin/clang clang; do if [ -n "$cc" ] && command -v "$cc" >/dev/null 2>&1 && "$cc" -print-targets 2>/dev/null | grep -q wasm32; then ar_dir="$(dirname "$(command -v "$cc")")"; ar="$ar_dir/llvm-ar"; [ -x "$ar" ] || ar="llvm-ar"; export CC_wasm32_unknown_unknown="$cc" CXX_wasm32_unknown_unknown="${cc}++" AR_wasm32_unknown_unknown="$ar"; echo "Using wasm clang: $cc"; break; fi; done; fi # shell2batch:
 cd crates/occara
 rustup run nightly wasm-pack test --node
 '''

--- a/crates/modeling-module/src/persistent_data.rs
+++ b/crates/modeling-module/src/persistent_data.rs
@@ -89,6 +89,6 @@ impl PersistentData {
         for e in b.edges() {
             f.add(0.2, &e);
         }
-        f.build()
+        f.build().expect("box fillet radius is valid")
     }
 }

--- a/crates/occara/Cargo.toml
+++ b/crates/occara/Cargo.toml
@@ -13,6 +13,7 @@ publish = false
 
 [dependencies]
 cxx.workspace = true
+thiserror.workspace = true
 walkdir.workspace = true
 
 [build-dependencies]

--- a/crates/occara/include/cxx_wrapper.hpp
+++ b/crates/occara/include/cxx_wrapper.hpp
@@ -1,7 +1,9 @@
 #pragma once
 #include "geom.hpp"
 #include "shape.hpp"
+#include <Standard_Failure.hxx>
 #include <memory>
+#include <stdexcept>
 
 // This file provides wrappers that adapt the existing C++ API to work with cxx
 // by returning std::unique_ptr instead of values
@@ -317,7 +319,11 @@ inline void FilletBuilder_add_edge(FilletBuilder& f, Standard_Real radius, const
 }
 
 inline std::unique_ptr<Shape> FilletBuilder_build(FilletBuilder& f) {
-    return std::make_unique<Shape>(f.build());
+    try {
+        return std::make_unique<Shape>(f.build());
+    } catch (const Standard_Failure& e) {
+        throw std::runtime_error(e.GetMessageString());
+    }
 }
 
 // ShellBuilder wrappers

--- a/crates/occara/src/ffi.rs
+++ b/crates/occara/src/ffi.rs
@@ -260,7 +260,8 @@ pub mod ffi {
             edge: &Edge,
         );
         #[namespace = "occara::shape"]
-        fn FilletBuilder_build(fillet_builder: Pin<&mut FilletBuilder>) -> UniquePtr<Shape>;
+        fn FilletBuilder_build(fillet_builder: Pin<&mut FilletBuilder>)
+            -> Result<UniquePtr<Shape>>;
 
         // ShellBuilder functions
         #[namespace = "occara::shape"]

--- a/crates/occara/src/make_bottle.rs
+++ b/crates/occara/src/make_bottle.rs
@@ -48,7 +48,9 @@ pub fn make_bottle_rust(width: f64, height: f64, thickness: f64) -> Shape {
         for edge in body.edges() {
             fillet_builder.add(fillet_radius, &edge);
         }
-        fillet_builder.build()
+        fillet_builder
+            .build()
+            .expect("bottle fillet radius is valid")
     };
 
     // Create the neck from a cylinder

--- a/crates/occara/src/shape.rs
+++ b/crates/occara/src/shape.rs
@@ -354,13 +354,20 @@ unsafe impl Sync for FaceIterator {}
 
 pub struct FilletBuilder(pub(crate) cxx::UniquePtr<ffi::FilletBuilder>);
 
+/// Error returned when OCCT cannot build a fillet, `OpenCASCADE`s fillet algorithm is highly complex
+/// and doesn't handle all cases. Usually the radius is too large for the geometry.
+#[derive(Debug, thiserror::Error)]
+#[error("Failed to build fillet: {0}")]
+pub struct FilletError(String);
+
 impl FilletBuilder {
     pub fn add(&mut self, radius: f64, edge: &Edge) {
         ffi::FilletBuilder_add_edge(self.0.pin_mut(), radius, &edge.0);
     }
-    #[must_use]
-    pub fn build(&mut self) -> Shape {
-        Shape(ffi::FilletBuilder_build(self.0.pin_mut()))
+    pub fn build(&mut self) -> Result<Shape, FilletError> {
+        ffi::FilletBuilder_build(self.0.pin_mut())
+            .map(Shape)
+            .map_err(|e| FilletError(e.what().to_string()))
     }
 }
 

--- a/crates/occara/tests/fillet_errors.rs
+++ b/crates/occara/tests/fillet_errors.rs
@@ -1,0 +1,27 @@
+use occara::{
+    geom::{Point, Vector},
+    shape::{Edge, Wire},
+};
+use wasm_bindgen_test::*;
+
+#[wasm_bindgen_test(unsupported = test)]
+fn test_huge_fillet_returns_err_not_crash() {
+    wasm_libc::init();
+    let p1 = Point::new(0.0, 0.0, 0.0);
+    let p2 = Point::new(1.0, 0.0, 0.0);
+    let p3 = Point::new(1.0, 1.0, 0.0);
+    let p4 = Point::new(0.0, 1.0, 0.0);
+    let wire = Wire::new(&[
+        &Edge::line(&p1, &p2),
+        &Edge::line(&p2, &p3),
+        &Edge::line(&p3, &p4),
+        &Edge::line(&p4, &p1),
+    ]);
+    let cube = wire.face().extrude(&Vector::new(0.0, 0.0, 1.0));
+    let edges: Vec<_> = cube.edges().collect();
+    let mut builder = cube.fillet();
+    for e in &edges {
+        builder.add(100.0, e);
+    }
+    assert!(builder.build().is_err(), "expected Err, not a crash");
+}

--- a/crates/opencascade-sys/src/lib.rs
+++ b/crates/opencascade-sys/src/lib.rs
@@ -156,10 +156,9 @@ impl OpenCascadeSource {
                     .define("CMAKE_CXX_COMPILER_WORKS", "TRUE")
                     .define("CMAKE_SIZEOF_VOID_P", "4");
 
-                // Disable OCC_CONVERT_SIGNALS for WASM - it uses setjmp/longjmp for signal
-                // handling, which is not supported in WASM. On Linux/macOS, this is
-                // automatically enabled by OpenCASCADE, so we must explicitly disable it.
-                config.define("OCC_CONVERT_SIGNALS", "OFF");
+                // Enable the WASM build path: -fwasm-exceptions and no OCC_CONVERT_SIGNALS
+                // (setjmp/longjmp signal handling is unsupported in WASM and conflicts with EH).
+                config.define("CADARA_WASM", "ON");
             }
 
             config.build();

--- a/crates/wasm-libc/src/lib.rs
+++ b/crates/wasm-libc/src/lib.rs
@@ -186,31 +186,6 @@ mod api {
     }
 
     #[no_mangle]
-    pub unsafe extern "C" fn __cxa_allocate_exception(thrown_size: usize) -> *mut u8 {
-        // Allocate memory for the exception object
-        // This is a stub - exceptions won't actually work, but we need to return
-        // valid memory to avoid immediate crashes. The exception will be "thrown"
-        // in __cxa_throw which will abort.
-        malloc(thrown_size)
-    }
-
-    #[no_mangle]
-    pub unsafe extern "C" fn __cxa_throw(
-        _thrown_exception: *mut u8,
-        _tinfo: *mut u8,
-        _dest: *mut u8,
-    ) -> ! {
-        // Exception handling is not yet implemented for WASM.
-        // According to OpenCASCADE documentation, exceptions should not be thrown
-        // during normal execution, but they're still present in the code.
-        error!(
-            "Exception thrown in WASM - this should not happen during normal OpenCASCADE execution"
-        );
-        error!("If you see this, there may be an error in the CAD operations");
-        process::abort();
-    }
-
-    #[no_mangle]
     pub unsafe extern "C" fn __cxa_atexit(a: i32, b: i32, c: i32) -> i32 {
         10
     }
@@ -314,6 +289,32 @@ mod api {
     pub unsafe extern "C" fn wmemcpy(dest: i32, src: i32, n: i32) -> i32 {
         std::ptr::copy_nonoverlapping(src as *const u8, dest as *mut u8, (n * 4) as usize);
         dest
+    }
+
+    #[no_mangle]
+    pub unsafe extern "C" fn wmemchr(s: i32, c: i32, n: i32) -> i32 {
+        let ptr = s as *const i32;
+        for i in 0..n {
+            if *ptr.add(i as usize) == c {
+                return s + i * 4;
+            }
+        }
+        0
+    }
+
+    #[no_mangle]
+    pub unsafe extern "C" fn strerror_r(_errnum: i32, _buf: i32, _buflen: i32) -> i32 {
+        error!("strerror_r not implemented");
+        0
+    }
+
+    unimplemented_function!(fgetwc, stream: i32);
+    unimplemented_function!(fputwc, wc: i32, stream: i32);
+    unimplemented_function!(ungetwc, wc: i32, stream: i32);
+
+    #[no_mangle]
+    pub unsafe extern "C" fn setbuf(_stream: i32, _buf: i32) {
+        error!("setbuf not implemented");
     }
 
     #[no_mangle]
@@ -636,6 +637,21 @@ mod api {
         } else {
             0
         }
+    }
+
+    #[no_mangle]
+    pub unsafe extern "C" fn isdigit(c: i32) -> i32 {
+        i32::from((c as u8).is_ascii_digit())
+    }
+
+    #[no_mangle]
+    pub unsafe extern "C" fn isxdigit(c: i32) -> i32 {
+        i32::from((c as u8).is_ascii_hexdigit())
+    }
+
+    #[no_mangle]
+    pub unsafe extern "C" fn aligned_alloc(_alignment: usize, size: usize) -> *mut u8 {
+        malloc(size)
     }
 
     #[no_mangle]


### PR DESCRIPTION
`FilletBuilder::build` now returns `Result<Shape, FilletError>`, so an `OpenCASCADE` failure such as a too-large fillet radius is caught instead of aborting on native or trapping on wasm.

Getting there meant making C++ exceptions actually work on `wasm32-unknown-unknown` for the first time (`-fwasm-exceptions` + an exception-enabled libc++/libunwind and the `__cpp_exception` tag), backed by the `wasm32-unknown-unknown-libcxx` v0.1.6 release and the `CADARA_WASM` flag on the OCCT fork (both landed separately).

For now this PR also switches from the `windows-latest` builder to `windows-2022` since there are some issues with cmake that need to be investigated more.