### PR TITLE
fix(project): use browser clock for `wall_clock` on wasm

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2896,6 +2896,7 @@ version = "0.1.0"
 dependencies = [
  "dyn-clone",
  "erased-serde",
+ "js-sys",
  "lazy_static",
  "log",
  "module",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,6 +57,7 @@ console_log = "1.0"
 log = "0.4"
 wasm-bindgen = "0.2"
 wasm-bindgen-test = "0.3"
+js-sys = "0.3"
 dagga = "0.2.3"
 
 [workspace.package]

--- a/crates/project/Cargo.toml
+++ b/crates/project/Cargo.toml
@@ -22,5 +22,8 @@ paste.workspace = true
 thiserror.workspace = true
 log.workspace = true
 
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+js-sys.workspace = true
+
 [dev-dependencies]
 lazy_static.workspace = true

--- a/crates/project/src/lib.rs
+++ b/crates/project/src/lib.rs
@@ -801,10 +801,23 @@ impl Project {
         LogEntry {
             lamport,
             session,
-            wall_clock: Some(std::time::SystemTime::now()),
+            wall_clock: Some(now_wall_clock()),
             payload,
         }
     }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn now_wall_clock() -> std::time::SystemTime {
+    std::time::SystemTime::now()
+}
+
+// wasm32-unknown-unknown has no wall clock, so SystemTime::now() panics. Read
+// the browser clock instead.
+#[cfg(target_arch = "wasm32")]
+fn now_wall_clock() -> std::time::SystemTime {
+    let millis = js_sys::Date::now().max(0.0) as u64;
+    std::time::UNIX_EPOCH + std::time::Duration::from_millis(millis)
 }
 
 /// Group entries by session and union their per-session active sets into a


### PR DESCRIPTION
`Project::new_entry` called `std::time::SystemTime::now()`, which panics on `wasm32-unknown-unknown` since the target has no wall clock. The browser build crashed at startup as soon as the first log entry was created. On wasm we now read the time from `js_sys::Date::now()` instead, so `wall_clock` stays populated for the eventual UI display.