### PR TITLE
feat(modeling-module): add sketch, extrude, and fillet modeling steps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -427,6 +427,7 @@ dependencies = [
  "modeling-workspace",
  "project",
  "tracing-subscriber",
+ "uuid",
  "viewport",
  "wasm-bindgen",
  "wasm-libc",

--- a/crates/cadara/Cargo.toml
+++ b/crates/cadara/Cargo.toml
@@ -20,6 +20,7 @@ workspace.workspace = true
 modeling-workspace.workspace = true
 modeling-module.workspace = true
 project.workspace = true
+uuid.workspace = true
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 tracing-subscriber.workspace = true

--- a/crates/cadara/src/lib.rs
+++ b/crates/cadara/src/lib.rs
@@ -3,18 +3,24 @@
 #![allow(clippy::module_name_repetitions)]
 #![allow(clippy::cognitive_complexity)]
 
-use iced::{time, Subscription};
+use modeling_module::operation::{
+    extrude::{Extrude, ExtrudeDirection, ExtrudeMode},
+    fillet::{Fillet, FilletTarget},
+    sketch::{Line, Plane, Point2D, Sketch, SketchPrimitive},
+    ModelingOperation,
+};
+use modeling_module::persistent_data::{Create, ModelingTransaction};
 use modeling_module::ModelingModule;
 use std::sync::Arc;
+use uuid::Uuid;
 use workspace::Workspace;
 
 struct App {
     viewport: viewport::Viewport,
+    #[expect(dead_code, reason = "kept so future demo edits can apply new changes")]
     project: project::Project,
+    #[expect(dead_code, reason = "kept so future demo edits can apply new changes")]
     project_view: Arc<project::ProjectView>,
-    data_uuid: project::DataId,
-    reg: project::ModuleRegistry,
-    tick_counter: u32,
 }
 
 impl Default for App {
@@ -24,8 +30,19 @@ impl Default for App {
 }
 
 #[derive(Debug)]
-enum Message {
-    Tick,
+enum Message {}
+
+fn square_xy() -> Sketch {
+    let mk = |from, to| (Uuid::new_v4(), SketchPrimitive::Line(Line { from, to }));
+    Sketch {
+        plane: Plane::XY,
+        primitives: vec![
+            mk(Point2D::new(0.0, 0.0), Point2D::new(1.0, 0.0)),
+            mk(Point2D::new(1.0, 0.0), Point2D::new(1.0, 1.0)),
+            mk(Point2D::new(1.0, 1.0), Point2D::new(0.0, 1.0)),
+            mk(Point2D::new(0.0, 1.0), Point2D::new(0.0, 0.0)),
+        ],
+    }
 }
 
 impl App {
@@ -37,21 +54,36 @@ impl App {
         let mut cb = project::ChangeBuilder::from(&project_view);
 
         let mut doc = project_view.create_document(&mut cb, "/doc".try_into().unwrap());
-        let data_uuid = *doc.create_data::<ModelingModule>();
         let mut data = doc.create_data::<ModelingModule>();
+        let data_uuid = *data;
 
-        data.apply_persistent(
-            modeling_module::persistent_data::ModelingTransaction::Create(
-                modeling_module::persistent_data::Create {
-                    id: uuid::Uuid::new_v4(),
-                    before: None,
-                    name: "demo".into(),
-                    operation: modeling_module::operation::ModelingOperation::Sketch(
-                        modeling_module::operation::sketch::Sketch::default(),
-                    ),
-                },
-            ),
-        );
+        let sketch_id = Uuid::new_v4();
+        data.apply_persistent(ModelingTransaction::Create(Create {
+            id: sketch_id,
+            before: None,
+            name: "sketch".into(),
+            operation: ModelingOperation::Sketch(square_xy()),
+        }));
+        data.apply_persistent(ModelingTransaction::Create(Create {
+            id: Uuid::new_v4(),
+            before: None,
+            name: "extrude".into(),
+            operation: ModelingOperation::Extrude(Extrude {
+                sketch_id,
+                depth: 0.3,
+                direction: ExtrudeDirection::Normal,
+                mode: ExtrudeMode::Add,
+            }),
+        }));
+        data.apply_persistent(ModelingTransaction::Create(Create {
+            id: Uuid::new_v4(),
+            before: None,
+            name: "fillet".into(),
+            operation: ModelingOperation::Fillet(Fillet {
+                radius: 0.1,
+                target: FilletTarget::WholeBody,
+            }),
+        }));
         project.apply_changes(cb, &reg).unwrap();
 
         let project_view = Arc::new(project.create_view(&reg).unwrap());
@@ -65,54 +97,15 @@ impl App {
             viewport,
             project,
             project_view,
-            data_uuid,
-            reg,
-            tick_counter: 0,
         }
     }
 
-    #[expect(clippy::needless_pass_by_value, reason = "required by iced")]
-    fn update(&mut self, message: Message) {
-        match message {
-            Message::Tick => {
-                let data = self
-                    .project_view
-                    .open_data_by_id::<ModelingModule>(self.data_uuid)
-                    .unwrap();
-
-                let mut cb = project::ChangeBuilder::from(&data);
-                if self.tick_counter > 100 {
-                    data.apply_persistent(
-                        modeling_module::persistent_data::ModelingTransaction::Create(
-                            modeling_module::persistent_data::Create {
-                                id: uuid::Uuid::new_v4(),
-                                before: None,
-                                name: "grow".into(),
-                                operation: modeling_module::operation::ModelingOperation::Grow,
-                            },
-                        ),
-                        &mut cb,
-                    );
-
-                    println!("grow");
-                    self.tick_counter = 0;
-                } else {
-                    let data = self
-                        .project_view
-                        .open_data_by_id::<ModelingModule>(self.data_uuid)
-                        .unwrap();
-
-                    let mut cb = project::ChangeBuilder::from(&data);
-
-                    data.apply_session((), &mut cb);
-                }
-                self.project.apply_changes(cb, &self.reg).unwrap();
-                self.project_view = Arc::new(self.project.create_view(&self.reg).unwrap());
-                self.viewport.update(self.project_view.clone());
-                self.tick_counter += 1;
-            }
-        }
-    }
+    #[expect(
+        clippy::unused_self,
+        clippy::missing_const_for_fn,
+        reason = "required by iced"
+    )]
+    fn update(&mut self, _message: Message) {}
 
     fn view(&self) -> iced::Element<'_, Message> {
         let viewport_shader = iced::widget::shader(&self.viewport)
@@ -120,11 +113,6 @@ impl App {
             .height(iced::Length::Fill);
 
         iced::widget::column!(iced::widget::text("Viewport:"), viewport_shader).into()
-    }
-
-    #[expect(clippy::unused_self)]
-    fn subscription(&self) -> Subscription<Message> {
-        time::every(time::Duration::from_millis(20)).map(|_| Message::Tick)
     }
 }
 
@@ -149,7 +137,6 @@ pub fn run_cadara() {
 
     iced::application(App::new, App::update, App::view)
         .title("CADara")
-        .subscription(App::subscription)
         .run()
         .unwrap();
 }

--- a/crates/cadara/src/lib.rs
+++ b/crates/cadara/src/lib.rs
@@ -46,7 +46,7 @@ impl App {
                     id: uuid::Uuid::new_v4(),
                     before: None,
                     operation: modeling_module::operation::ModelingOperation::Sketch(
-                        modeling_module::operation::sketch::Sketch,
+                        modeling_module::operation::sketch::Sketch::default(),
                     ),
                 },
             ),

--- a/crates/cadara/src/lib.rs
+++ b/crates/cadara/src/lib.rs
@@ -45,6 +45,7 @@ impl App {
                 modeling_module::persistent_data::Create {
                     id: uuid::Uuid::new_v4(),
                     before: None,
+                    name: "demo".into(),
                     operation: modeling_module::operation::ModelingOperation::Sketch(
                         modeling_module::operation::sketch::Sketch::default(),
                     ),
@@ -86,6 +87,7 @@ impl App {
                             modeling_module::persistent_data::Create {
                                 id: uuid::Uuid::new_v4(),
                                 before: None,
+                                name: "grow".into(),
                                 operation: modeling_module::operation::ModelingOperation::Grow,
                             },
                         ),

--- a/crates/cadara/src/lib.rs
+++ b/crates/cadara/src/lib.rs
@@ -5,7 +5,7 @@
 
 use iced::{time, Subscription};
 use modeling_module::operation::{
-    extrude::{Extrude, ExtrudeDirection, ExtrudeMode},
+    extrude::{Extrude, ExtrudeChange, ExtrudeDirection, ExtrudeMode},
     fillet::{Fillet, FilletTarget},
     sketch::{Line, Plane, Point2D, Sketch, SketchPrimitive},
     ModelingOperation,
@@ -18,9 +18,13 @@ use workspace::Workspace;
 
 struct App {
     viewport: viewport::Viewport,
-    #[expect(dead_code, reason = "kept so future demo edits can apply new changes")]
     project: project::Project,
     project_view: Arc<project::ProjectView>,
+    reg: project::ModuleRegistry,
+    data_uuid: project::DataId,
+    extrude_id: Uuid,
+    depth: f64,
+    tick: u32,
 }
 
 impl Default for App {
@@ -66,8 +70,9 @@ impl App {
             name: "sketch".into(),
             operation: ModelingOperation::Sketch(square_xy()),
         }));
+        let extrude_id = Uuid::new_v4();
         data.apply_persistent(ModelingTransaction::Create(Create {
-            id: Uuid::new_v4(),
+            id: extrude_id,
             before: None,
             name: "extrude".into(),
             operation: ModelingOperation::Extrude(Extrude {
@@ -99,17 +104,45 @@ impl App {
             viewport,
             project,
             project_view,
+            reg,
+            data_uuid,
+            extrude_id,
+            depth: 0.3,
+            tick: 0,
         }
     }
 
     fn update(&mut self, message: Message) {
         match message {
             Message::Tick => {
-                // Bump the viewport's project_view version so the shader
-                // re-renders. The Program::update path mutates camera state
-                // through a Mutex but does not request a redraw on its own,
-                // so without periodic ticks rotation, panning and resize
-                // would never appear on screen.
+                self.tick += 1;
+                // Periodically grow the extrude depth so the demo applies real
+                // changes through the project, not just redraws.
+                if self.tick >= 100 {
+                    self.tick = 0;
+                    self.depth = if self.depth >= 0.6 {
+                        0.3
+                    } else {
+                        self.depth + 0.1
+                    };
+                    let data = self
+                        .project_view
+                        .open_data_by_id::<ModelingModule>(self.data_uuid)
+                        .unwrap();
+                    let mut cb = project::ChangeBuilder::from(&data);
+                    data.apply_persistent(
+                        ModelingTransaction::EditExtrude {
+                            step_id: self.extrude_id,
+                            change: ExtrudeChange::SetDepth(self.depth),
+                        },
+                        &mut cb,
+                    );
+                    self.project.apply_changes(cb, &self.reg).unwrap();
+                    self.project_view = Arc::new(self.project.create_view(&self.reg).unwrap());
+                }
+                // Ticks also drive redraws: Program::update mutates camera state
+                // through a Mutex but does not request a redraw on its own, so
+                // without them rotation, panning and resize never reach the screen.
                 self.viewport.update(self.project_view.clone());
             }
         }

--- a/crates/cadara/src/lib.rs
+++ b/crates/cadara/src/lib.rs
@@ -43,6 +43,7 @@ impl App {
         data.apply_persistent(
             modeling_module::persistent_data::ModelingTransaction::Create(
                 modeling_module::persistent_data::Create {
+                    id: uuid::Uuid::new_v4(),
                     before: None,
                     operation: modeling_module::operation::ModelingOperation::Sketch(
                         modeling_module::operation::sketch::Sketch,
@@ -83,6 +84,7 @@ impl App {
                     data.apply_persistent(
                         modeling_module::persistent_data::ModelingTransaction::Create(
                             modeling_module::persistent_data::Create {
+                                id: uuid::Uuid::new_v4(),
                                 before: None,
                                 operation: modeling_module::operation::ModelingOperation::Grow,
                             },

--- a/crates/cadara/src/lib.rs
+++ b/crates/cadara/src/lib.rs
@@ -3,6 +3,7 @@
 #![allow(clippy::module_name_repetitions)]
 #![allow(clippy::cognitive_complexity)]
 
+use iced::{time, Subscription};
 use modeling_module::operation::{
     extrude::{Extrude, ExtrudeDirection, ExtrudeMode},
     fillet::{Fillet, FilletTarget},
@@ -19,7 +20,6 @@ struct App {
     viewport: viewport::Viewport,
     #[expect(dead_code, reason = "kept so future demo edits can apply new changes")]
     project: project::Project,
-    #[expect(dead_code, reason = "kept so future demo edits can apply new changes")]
     project_view: Arc<project::ProjectView>,
 }
 
@@ -29,8 +29,10 @@ impl Default for App {
     }
 }
 
-#[derive(Debug)]
-enum Message {}
+#[derive(Debug, Clone, Copy)]
+enum Message {
+    Tick,
+}
 
 fn square_xy() -> Sketch {
     let mk = |from, to| (Uuid::new_v4(), SketchPrimitive::Line(Line { from, to }));
@@ -100,12 +102,18 @@ impl App {
         }
     }
 
-    #[expect(
-        clippy::unused_self,
-        clippy::missing_const_for_fn,
-        reason = "required by iced"
-    )]
-    fn update(&mut self, _message: Message) {}
+    fn update(&mut self, message: Message) {
+        match message {
+            Message::Tick => {
+                // Bump the viewport's project_view version so the shader
+                // re-renders. The Program::update path mutates camera state
+                // through a Mutex but does not request a redraw on its own,
+                // so without periodic ticks rotation, panning and resize
+                // would never appear on screen.
+                self.viewport.update(self.project_view.clone());
+            }
+        }
+    }
 
     fn view(&self) -> iced::Element<'_, Message> {
         let viewport_shader = iced::widget::shader(&self.viewport)
@@ -113,6 +121,11 @@ impl App {
             .height(iced::Length::Fill);
 
         iced::widget::column!(iced::widget::text("Viewport:"), viewport_shader).into()
+    }
+
+    #[expect(clippy::unused_self, reason = "iced subscription takes &self")]
+    fn subscription(&self) -> Subscription<Message> {
+        time::every(time::Duration::from_millis(20)).map(|_| Message::Tick)
     }
 }
 
@@ -137,6 +150,7 @@ pub fn run_cadara() {
 
     iced::application(App::new, App::update, App::view)
         .title("CADara")
+        .subscription(App::subscription)
         .run()
         .unwrap();
 }

--- a/crates/modeling-module/src/operation.rs
+++ b/crates/modeling-module/src/operation.rs
@@ -17,6 +17,4 @@ pub enum ModelingOperation {
     Sketch(sketch::Sketch),
     Extrude(extrude::Extrude),
     Fillet(fillet::Fillet),
-    Grow,
-    Shrink,
 }

--- a/crates/modeling-module/src/operation.rs
+++ b/crates/modeling-module/src/operation.rs
@@ -1,7 +1,15 @@
 use serde::{Deserialize, Serialize};
+use std::{fmt::Debug, hash::Hash};
 
 pub mod extrude;
 pub mod sketch;
+
+pub trait Operation:
+    Clone + Debug + Eq + Hash + Serialize + for<'de> Deserialize<'de> + Send + Sync
+{
+    type Change: Clone + Debug + Eq + Hash + Serialize + for<'de> Deserialize<'de> + Send + Sync;
+    fn apply_change(&mut self, change: Self::Change);
+}
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Hash)]
 pub enum ModelingOperation {

--- a/crates/modeling-module/src/operation.rs
+++ b/crates/modeling-module/src/operation.rs
@@ -2,6 +2,7 @@ use serde::{Deserialize, Serialize};
 use std::{fmt::Debug, hash::Hash};
 
 pub mod extrude;
+pub mod fillet;
 pub mod sketch;
 
 pub trait Operation:
@@ -15,6 +16,7 @@ pub trait Operation:
 pub enum ModelingOperation {
     Sketch(sketch::Sketch),
     Extrude(extrude::Extrude),
+    Fillet(fillet::Fillet),
     Grow,
     Shrink,
 }

--- a/crates/modeling-module/src/operation/extrude.rs
+++ b/crates/modeling-module/src/operation/extrude.rs
@@ -1,9 +1,94 @@
 use serde::{Deserialize, Serialize};
+use std::hash::{Hash, Hasher};
+use uuid::Uuid;
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Hash)]
-pub struct Extrude;
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Extrude {
+    pub sketch_id: Uuid,
+    pub depth: f64,
+    pub direction: ExtrudeDirection,
+    pub mode: ExtrudeMode,
+}
+
+impl Eq for Extrude {}
+
+impl Hash for Extrude {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.sketch_id.hash(state);
+        self.depth.to_bits().hash(state);
+        self.direction.hash(state);
+        self.mode.hash(state);
+    }
+}
+
+impl Default for Extrude {
+    fn default() -> Self {
+        Self {
+            sketch_id: Uuid::nil(),
+            depth: 1.0,
+            direction: ExtrudeDirection::Normal,
+            mode: ExtrudeMode::Add,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum ExtrudeDirection {
+    #[default]
+    Normal,
+    Reversed,
+    Symmetric,
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum ExtrudeMode {
+    #[default]
+    Add,
+    Subtract,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub enum ExtrudeChange {
+    SetSketchId(Uuid),
+    SetDepth(f64),
+    SetDirection(ExtrudeDirection),
+    SetMode(ExtrudeMode),
+}
+
+impl Eq for ExtrudeChange {}
+
+impl Hash for ExtrudeChange {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        match self {
+            Self::SetSketchId(id) => {
+                0u8.hash(state);
+                id.hash(state);
+            }
+            Self::SetDepth(d) => {
+                1u8.hash(state);
+                d.to_bits().hash(state);
+            }
+            Self::SetDirection(d) => {
+                2u8.hash(state);
+                d.hash(state);
+            }
+            Self::SetMode(m) => {
+                3u8.hash(state);
+                m.hash(state);
+            }
+        }
+    }
+}
 
 impl crate::operation::Operation for Extrude {
-    type Change = ();
-    fn apply_change(&mut self, _change: ()) {}
+    type Change = ExtrudeChange;
+
+    fn apply_change(&mut self, change: ExtrudeChange) {
+        match change {
+            ExtrudeChange::SetSketchId(id) => self.sketch_id = id,
+            ExtrudeChange::SetDepth(d) => self.depth = d,
+            ExtrudeChange::SetDirection(d) => self.direction = d,
+            ExtrudeChange::SetMode(m) => self.mode = m,
+        }
+    }
 }

--- a/crates/modeling-module/src/operation/extrude.rs
+++ b/crates/modeling-module/src/operation/extrude.rs
@@ -2,3 +2,8 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Hash)]
 pub struct Extrude;
+
+impl crate::operation::Operation for Extrude {
+    type Change = ();
+    fn apply_change(&mut self, _change: ()) {}
+}

--- a/crates/modeling-module/src/operation/fillet.rs
+++ b/crates/modeling-module/src/operation/fillet.rs
@@ -1,0 +1,77 @@
+use serde::{Deserialize, Serialize};
+use std::hash::{Hash, Hasher};
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Fillet {
+    pub radius: f64,
+    pub target: FilletTarget,
+}
+
+impl Eq for Fillet {}
+
+impl Hash for Fillet {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.radius.to_bits().hash(state);
+        self.target.hash(state);
+    }
+}
+
+impl Default for Fillet {
+    fn default() -> Self {
+        Self {
+            radius: 0.1,
+            target: FilletTarget::WholeBody,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum FilletTarget {
+    WholeBody,
+    Face(FaceRef),
+    Edges(Vec<EdgeRef>),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct FaceRef {
+    pub index: usize,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct EdgeRef {
+    pub index: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub enum FilletChange {
+    SetRadius(f64),
+    SetTarget(FilletTarget),
+}
+
+impl Eq for FilletChange {}
+
+impl Hash for FilletChange {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        match self {
+            Self::SetRadius(r) => {
+                0u8.hash(state);
+                r.to_bits().hash(state);
+            }
+            Self::SetTarget(t) => {
+                1u8.hash(state);
+                t.hash(state);
+            }
+        }
+    }
+}
+
+impl crate::operation::Operation for Fillet {
+    type Change = FilletChange;
+
+    fn apply_change(&mut self, change: FilletChange) {
+        match change {
+            FilletChange::SetRadius(r) => self.radius = r,
+            FilletChange::SetTarget(t) => self.target = t,
+        }
+    }
+}

--- a/crates/modeling-module/src/operation/sketch.rs
+++ b/crates/modeling-module/src/operation/sketch.rs
@@ -2,3 +2,8 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Hash)]
 pub struct Sketch;
+
+impl crate::operation::Operation for Sketch {
+    type Change = ();
+    fn apply_change(&mut self, _change: ()) {}
+}

--- a/crates/modeling-module/src/operation/sketch.rs
+++ b/crates/modeling-module/src/operation/sketch.rs
@@ -1,9 +1,216 @@
 use serde::{Deserialize, Serialize};
+use std::hash::{Hash, Hasher};
+use uuid::Uuid;
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Hash)]
-pub struct Sketch;
+#[derive(Debug, Clone, Copy, Default, PartialEq, Serialize, Deserialize)]
+pub struct Point2D {
+    pub x: f64,
+    pub y: f64,
+}
+
+impl Point2D {
+    #[must_use]
+    pub const fn new(x: f64, y: f64) -> Self {
+        Self { x, y }
+    }
+}
+
+impl Eq for Point2D {}
+
+impl Hash for Point2D {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.x.to_bits().hash(state);
+        self.y.to_bits().hash(state);
+    }
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct Sketch {
+    pub plane: Plane,
+    pub primitives: Vec<(Uuid, SketchPrimitive)>,
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum Plane {
+    #[default]
+    XY,
+    YZ,
+    XZ,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum SketchPrimitive {
+    Line(Line),
+    Circle(Circle),
+    Arc(Arc),
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Line {
+    pub from: Point2D,
+    pub to: Point2D,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Circle {
+    pub center: Point2D,
+    pub radius: f64,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Arc {
+    pub from: Point2D,
+    pub through: Point2D,
+    pub to: Point2D,
+}
+
+impl Eq for Line {}
+impl Eq for Circle {}
+impl Eq for Arc {}
+
+impl Hash for Line {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.from.hash(state);
+        self.to.hash(state);
+    }
+}
+
+impl Hash for Circle {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.center.hash(state);
+        self.radius.to_bits().hash(state);
+    }
+}
+
+impl Hash for Arc {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.from.hash(state);
+        self.through.hash(state);
+        self.to.hash(state);
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum SketchChange {
+    SetPlane(Plane),
+    AddPrimitive {
+        id: Uuid,
+        before: Option<Uuid>,
+        primitive: SketchPrimitive,
+    },
+    DeletePrimitive {
+        id: Uuid,
+    },
+    ReorderPrimitive {
+        id: Uuid,
+        before: Option<Uuid>,
+    },
+    EditPrimitive {
+        id: Uuid,
+        change: PrimitiveChange,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum PrimitiveChange {
+    Line(LineChange),
+    Circle(CircleChange),
+    Arc(ArcChange),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum LineChange {
+    SetFrom(Point2D),
+    SetTo(Point2D),
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub enum CircleChange {
+    SetCenter(Point2D),
+    SetRadius(f64),
+}
+
+impl Eq for CircleChange {}
+
+impl Hash for CircleChange {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        match self {
+            Self::SetCenter(p) => {
+                0u8.hash(state);
+                p.hash(state);
+            }
+            Self::SetRadius(r) => {
+                1u8.hash(state);
+                r.to_bits().hash(state);
+            }
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum ArcChange {
+    SetFrom(Point2D),
+    SetThrough(Point2D),
+    SetTo(Point2D),
+}
 
 impl crate::operation::Operation for Sketch {
-    type Change = ();
-    fn apply_change(&mut self, _change: ()) {}
+    type Change = SketchChange;
+
+    fn apply_change(&mut self, change: SketchChange) {
+        match change {
+            SketchChange::SetPlane(p) => self.plane = p,
+            SketchChange::AddPrimitive {
+                id,
+                before,
+                primitive,
+            } => {
+                if self.primitives.iter().any(|(i, _)| *i == id) {
+                    return;
+                }
+                let pos = before
+                    .and_then(|a| self.primitives.iter().position(|(i, _)| *i == a))
+                    .unwrap_or(self.primitives.len());
+                self.primitives.insert(pos, (id, primitive));
+            }
+            SketchChange::DeletePrimitive { id } => {
+                self.primitives.retain(|(i, _)| *i != id);
+            }
+            SketchChange::ReorderPrimitive { id, before } => {
+                let Some(from) = self.primitives.iter().position(|(i, _)| *i == id) else {
+                    return;
+                };
+                let item = self.primitives.remove(from);
+                let to = before
+                    .and_then(|a| self.primitives.iter().position(|(i, _)| *i == a))
+                    .unwrap_or(self.primitives.len());
+                self.primitives.insert(to, item);
+            }
+            SketchChange::EditPrimitive { id, change } => {
+                let Some(slot) = self.primitives.iter_mut().find(|(i, _)| *i == id) else {
+                    return;
+                };
+                apply_primitive_change(&mut slot.1, change);
+            }
+        }
+    }
+}
+
+const fn apply_primitive_change(prim: &mut SketchPrimitive, change: PrimitiveChange) {
+    match (prim, change) {
+        (SketchPrimitive::Line(l), PrimitiveChange::Line(c)) => match c {
+            LineChange::SetFrom(p) => l.from = p,
+            LineChange::SetTo(p) => l.to = p,
+        },
+        (SketchPrimitive::Circle(c), PrimitiveChange::Circle(ch)) => match ch {
+            CircleChange::SetCenter(p) => c.center = p,
+            CircleChange::SetRadius(r) => c.radius = r,
+        },
+        (SketchPrimitive::Arc(a), PrimitiveChange::Arc(ch)) => match ch {
+            ArcChange::SetFrom(p) => a.from = p,
+            ArcChange::SetThrough(p) => a.through = p,
+            ArcChange::SetTo(p) => a.to = p,
+        },
+        _ => {}
+    }
 }

--- a/crates/modeling-module/src/operation/sketch.rs
+++ b/crates/modeling-module/src/operation/sketch.rs
@@ -95,15 +95,10 @@ pub enum SketchChange {
     SetPlane(Plane),
     AddPrimitive {
         id: Uuid,
-        before: Option<Uuid>,
         primitive: SketchPrimitive,
     },
     DeletePrimitive {
         id: Uuid,
-    },
-    ReorderPrimitive {
-        id: Uuid,
-        before: Option<Uuid>,
     },
     EditPrimitive {
         id: Uuid,
@@ -160,31 +155,14 @@ impl crate::operation::Operation for Sketch {
     fn apply_change(&mut self, change: SketchChange) {
         match change {
             SketchChange::SetPlane(p) => self.plane = p,
-            SketchChange::AddPrimitive {
-                id,
-                before,
-                primitive,
-            } => {
+            SketchChange::AddPrimitive { id, primitive } => {
                 if self.primitives.iter().any(|(i, _)| *i == id) {
                     return;
                 }
-                let pos = before
-                    .and_then(|a| self.primitives.iter().position(|(i, _)| *i == a))
-                    .unwrap_or(self.primitives.len());
-                self.primitives.insert(pos, (id, primitive));
+                self.primitives.push((id, primitive));
             }
             SketchChange::DeletePrimitive { id } => {
                 self.primitives.retain(|(i, _)| *i != id);
-            }
-            SketchChange::ReorderPrimitive { id, before } => {
-                let Some(from) = self.primitives.iter().position(|(i, _)| *i == id) else {
-                    return;
-                };
-                let item = self.primitives.remove(from);
-                let to = before
-                    .and_then(|a| self.primitives.iter().position(|(i, _)| *i == a))
-                    .unwrap_or(self.primitives.len());
-                self.primitives.insert(to, item);
             }
             SketchChange::EditPrimitive { id, change } => {
                 let Some(slot) = self.primitives.iter_mut().find(|(i, _)| *i == id) else {

--- a/crates/modeling-module/src/persistent_data.rs
+++ b/crates/modeling-module/src/persistent_data.rs
@@ -1,10 +1,12 @@
-use crate::operation::extrude::ExtrudeChange;
-use crate::operation::fillet::FilletChange;
-use crate::operation::sketch::{SketchChange, SketchPrimitive};
+use crate::operation::extrude::{Extrude, ExtrudeChange, ExtrudeDirection, ExtrudeMode};
+use crate::operation::fillet::{Fillet, FilletChange, FilletTarget};
+use crate::operation::sketch::{Plane, Point2D, Sketch, SketchChange, SketchPrimitive};
 use crate::operation::{ModelingOperation, Operation};
 use module::DataSection;
-use occara::shape::{Compound, Shape};
+use occara::geom::{Direction, Point, Vector};
+use occara::shape::{Compound, Edge, Face, Shape, Wire};
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 use uuid::Uuid;
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -149,11 +151,159 @@ impl DataSection for PersistentData {
 }
 
 impl PersistentData {
-    /// Placeholder. The real walk lands in Task 8.
     #[must_use]
     pub fn shape(&self) -> Shape {
-        let mut c = Compound::builder();
-        c.build()
+        let mut state = WalkState::new();
+        for step in &self.steps {
+            state.apply(step);
+        }
+        state.body
+    }
+}
+
+struct WalkState {
+    body: Shape,
+    sketch_outputs: HashMap<Uuid, (Face, Plane)>,
+}
+
+impl WalkState {
+    fn new() -> Self {
+        Self {
+            body: Compound::builder().build(),
+            sketch_outputs: HashMap::new(),
+        }
+    }
+
+    fn apply(&mut self, step: &Step) {
+        match &step.operation {
+            ModelingOperation::Sketch(s) => self.apply_sketch(step.id, s),
+            ModelingOperation::Extrude(e) => self.apply_extrude(e),
+            ModelingOperation::Fillet(f) => self.apply_fillet(f),
+        }
+    }
+
+    fn apply_sketch(&mut self, step_id: Uuid, sketch: &Sketch) {
+        let edges: Vec<Edge> = sketch
+            .primitives
+            .iter()
+            .map(|(_, p)| build_edge(p, sketch.plane))
+            .collect();
+        if edges.is_empty() {
+            return;
+        }
+        let edge_refs: Vec<&Edge> = edges.iter().collect();
+        let trait_refs: Vec<&dyn occara::shape::AddableToWire> = edge_refs
+            .iter()
+            .map(|e| *e as &dyn occara::shape::AddableToWire)
+            .collect();
+        let wire = Wire::new(&trait_refs);
+        let face = wire.face();
+        self.sketch_outputs.insert(step_id, (face, sketch.plane));
+    }
+
+    fn apply_extrude(&mut self, e: &Extrude) {
+        let Some((face, plane)) = self.sketch_outputs.get(&e.sketch_id) else {
+            return;
+        };
+        let normal = plane_normal(*plane);
+        let extrusion = match e.direction {
+            ExtrudeDirection::Normal => face.extrude(&scaled_vector(&normal, e.depth)),
+            ExtrudeDirection::Reversed => face.extrude(&scaled_vector(&normal, -e.depth)),
+            ExtrudeDirection::Symmetric => {
+                let half = e.depth / 2.0;
+                let up = face.extrude(&scaled_vector(&normal, half));
+                let down = face.extrude(&scaled_vector(&normal, -half));
+                up.fuse(&down)
+            }
+        };
+        self.body = match e.mode {
+            ExtrudeMode::Add => {
+                if body_is_empty(&self.body) {
+                    extrusion
+                } else {
+                    self.body.fuse(&extrusion)
+                }
+            }
+            ExtrudeMode::Subtract => {
+                if body_is_empty(&self.body) {
+                    return;
+                }
+                self.body.subtract(&extrusion)
+            }
+        };
+    }
+
+    fn apply_fillet(&mut self, f: &Fillet) {
+        let edges: Vec<Edge> = self.body.edges().collect();
+        let chosen: Vec<Edge> = match &f.target {
+            FilletTarget::WholeBody => edges,
+            FilletTarget::Face(face_ref) => {
+                let Some(face) = self.body.faces().nth(face_ref.index) else {
+                    return;
+                };
+                face.edges().collect()
+            }
+            FilletTarget::Edges(refs) => refs
+                .iter()
+                .filter_map(|er| edges.get(er.index).cloned())
+                .collect(),
+        };
+        if chosen.is_empty() {
+            return;
+        }
+        let mut builder = self.body.fillet();
+        for edge in &chosen {
+            builder.add(f.radius, edge);
+        }
+        if let Ok(filleted) = builder.build() {
+            self.body = filleted;
+        }
+    }
+}
+
+fn body_is_empty(shape: &Shape) -> bool {
+    shape.faces().next().is_none()
+}
+
+fn plane_normal(plane: Plane) -> Direction {
+    match plane {
+        Plane::XY => Direction::z(),
+        Plane::YZ => Direction::x(),
+        Plane::XZ => Direction::y(),
+    }
+}
+
+fn scaled_vector(d: &Direction, s: f64) -> Vector {
+    let (dx, dy, dz) = d.get_components();
+    Vector::new(dx * s, dy * s, dz * s)
+}
+
+fn lift(plane: Plane, p: Point2D) -> Point {
+    match plane {
+        Plane::XY => Point::new(p.x, p.y, 0.0),
+        Plane::YZ => Point::new(0.0, p.x, p.y),
+        Plane::XZ => Point::new(p.x, 0.0, p.y),
+    }
+}
+
+fn build_edge(prim: &SketchPrimitive, plane: Plane) -> Edge {
+    match prim {
+        SketchPrimitive::Line(l) => {
+            let a = lift(plane, l.from);
+            let b = lift(plane, l.to);
+            Edge::line(&a, &b)
+        }
+        SketchPrimitive::Circle(c) => {
+            let center = lift(plane, c.center);
+            let normal = plane_normal(plane);
+            Edge::circle(&center, &normal, c.radius)
+        }
+        SketchPrimitive::Arc(a) => {
+            let p1 = lift(plane, a.from);
+            let p2 = lift(plane, a.through);
+            let p3 = lift(plane, a.to);
+            Edge::arc_of_circle(&p1, &p2, &p3)
+        }
     }
 }
 

--- a/crates/modeling-module/src/persistent_data.rs
+++ b/crates/modeling-module/src/persistent_data.rs
@@ -316,7 +316,6 @@ fn sketch_undo_name(c: &SketchChange) -> String {
             SketchPrimitive::Arc(_) => "Add arc",
         },
         SketchChange::DeletePrimitive { .. } => "Del primitive",
-        SketchChange::ReorderPrimitive { .. } => "Move primitive",
         SketchChange::EditPrimitive { .. } => "Edit primitive",
     }
     .into()

--- a/crates/modeling-module/src/persistent_data.rs
+++ b/crates/modeling-module/src/persistent_data.rs
@@ -1,9 +1,9 @@
-use crate::operation::ModelingOperation;
+use crate::operation::extrude::ExtrudeChange;
+use crate::operation::fillet::FilletChange;
+use crate::operation::sketch::{SketchChange, SketchPrimitive};
+use crate::operation::{ModelingOperation, Operation};
 use module::DataSection;
-use occara::{
-    geom::{Point, Vector},
-    shape::{Edge, Wire},
-};
+use occara::shape::{Compound, Shape};
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
@@ -19,18 +19,56 @@ pub struct PersistentData {
     steps: Vec<Step>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Hash)]
+impl PersistentData {
+    #[must_use]
+    pub fn steps(&self) -> &[Step] {
+        &self.steps
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum ModelingTransaction {
+    Create(Create),
+    Delete(Delete),
+    Rename(Rename),
+    Reorder(Reorder),
+    EditSketch {
+        step_id: Uuid,
+        change: SketchChange,
+    },
+    EditExtrude {
+        step_id: Uuid,
+        change: ExtrudeChange,
+    },
+    EditFillet {
+        step_id: Uuid,
+        change: FilletChange,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct Create {
     pub id: Uuid,
     pub before: Option<Uuid>,
+    pub name: String,
     pub operation: ModelingOperation,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Hash)]
-pub enum ModelingTransaction {
-    Create(Create),
-    Update,
-    Delete,
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct Delete {
+    pub id: Uuid,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct Rename {
+    pub id: Uuid,
+    pub new_name: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct Reorder {
+    pub id: Uuid,
+    pub before: Option<Uuid>,
 }
 
 impl DataSection for PersistentData {
@@ -39,61 +77,115 @@ impl DataSection for PersistentData {
     fn apply(&mut self, args: Self::Args) {
         match args {
             ModelingTransaction::Create(c) => {
-                self.steps.push(Step {
-                    id: c.id,
-                    name: "new operation".to_string(),
-                    operation: c.operation,
-                });
+                if self.steps.iter().any(|s| s.id == c.id) {
+                    return;
+                }
+                let pos = c
+                    .before
+                    .and_then(|a| self.steps.iter().position(|s| s.id == a))
+                    .unwrap_or(self.steps.len());
+                self.steps.insert(
+                    pos,
+                    Step {
+                        id: c.id,
+                        name: c.name,
+                        operation: c.operation,
+                    },
+                );
             }
-            ModelingTransaction::Update => todo!(),
-            ModelingTransaction::Delete => todo!(),
+            ModelingTransaction::Delete(Delete { id }) => {
+                self.steps.retain(|s| s.id != id);
+            }
+            ModelingTransaction::Rename(Rename { id, new_name }) => {
+                if let Some(s) = self.steps.iter_mut().find(|s| s.id == id) {
+                    s.name = new_name;
+                }
+            }
+            ModelingTransaction::Reorder(Reorder { id, before }) => {
+                let Some(from) = self.steps.iter().position(|s| s.id == id) else {
+                    return;
+                };
+                let item = self.steps.remove(from);
+                let to = before
+                    .and_then(|a| self.steps.iter().position(|s| s.id == a))
+                    .unwrap_or(self.steps.len());
+                self.steps.insert(to, item);
+            }
+            ModelingTransaction::EditSketch { step_id, change } => {
+                if let Some(s) = self.steps.iter_mut().find(|s| s.id == step_id) {
+                    if let ModelingOperation::Sketch(ref mut op) = s.operation {
+                        op.apply_change(change);
+                    }
+                }
+            }
+            ModelingTransaction::EditExtrude { step_id, change } => {
+                if let Some(s) = self.steps.iter_mut().find(|s| s.id == step_id) {
+                    if let ModelingOperation::Extrude(ref mut op) = s.operation {
+                        op.apply_change(change);
+                    }
+                }
+            }
+            ModelingTransaction::EditFillet { step_id, change } => {
+                if let Some(s) = self.steps.iter_mut().find(|s| s.id == step_id) {
+                    if let ModelingOperation::Fillet(ref mut op) = s.operation {
+                        op.apply_change(change);
+                    }
+                }
+            }
         }
     }
 
-    fn undo_history_name(_args: &Self::Args) -> String {
-        String::new()
+    fn undo_history_name(args: &Self::Args) -> String {
+        match args {
+            ModelingTransaction::Create(_) => "Create".into(),
+            ModelingTransaction::Delete(_) => "Delete".into(),
+            ModelingTransaction::Rename(_) => "Rename".into(),
+            ModelingTransaction::Reorder(_) => "Reorder".into(),
+            ModelingTransaction::EditSketch { change, .. } => sketch_undo_name(change),
+            ModelingTransaction::EditExtrude { change, .. } => extrude_undo_name(change),
+            ModelingTransaction::EditFillet { change, .. } => fillet_undo_name(change),
+        }
     }
 }
 
 impl PersistentData {
-    /// # Panics
-    /// Panics if filleting the box fails, which should not happen for the fixed 0.2 radius used here.
+    /// Placeholder. The real walk lands in Task 8.
     #[must_use]
-    pub fn shape(&self) -> occara::shape::Shape {
-        let mut scale = 1.0;
-        for _ in self
-            .steps
-            .iter()
-            .filter(|s| matches!(s.operation, ModelingOperation::Grow))
-        {
-            scale *= 1.02;
-        }
-
-        for _ in self
-            .steps
-            .iter()
-            .filter(|s| matches!(s.operation, ModelingOperation::Shrink))
-        {
-            scale /= 1.02;
-        }
-        let wire = {
-            let p1 = Point::new(0.0, 0.0, 0.0);
-            let p2 = Point::new(0.0, scale, 0.0);
-            let p3 = Point::new(scale, scale, 0.0);
-            let p4 = Point::new(scale, 0.0, 0.0);
-            Wire::new(&[
-                &Edge::line(&p1, &p2),
-                &Edge::line(&p2, &p3),
-                &Edge::line(&p3, &p4),
-                &Edge::line(&p4, &p1),
-            ])
-        };
-        let b = wire.face().extrude(&Vector::new(0.0, 0.0, scale));
-
-        let mut f = b.fillet();
-        for e in b.edges() {
-            f.add(0.2, &e);
-        }
-        f.build().expect("box fillet radius is valid")
+    pub fn shape(&self) -> Shape {
+        let mut c = Compound::builder();
+        c.build()
     }
+}
+
+fn sketch_undo_name(c: &SketchChange) -> String {
+    match c {
+        SketchChange::SetPlane(_) => "Set plane",
+        SketchChange::AddPrimitive { primitive, .. } => match primitive {
+            SketchPrimitive::Line(_) => "Add line",
+            SketchPrimitive::Circle(_) => "Add circle",
+            SketchPrimitive::Arc(_) => "Add arc",
+        },
+        SketchChange::DeletePrimitive { .. } => "Del primitive",
+        SketchChange::ReorderPrimitive { .. } => "Move primitive",
+        SketchChange::EditPrimitive { .. } => "Edit primitive",
+    }
+    .into()
+}
+
+fn extrude_undo_name(c: &ExtrudeChange) -> String {
+    match c {
+        ExtrudeChange::SetSketchId(_) => "Set sketch",
+        ExtrudeChange::SetDepth(_) => "Set depth",
+        ExtrudeChange::SetDirection(_) => "Set direction",
+        ExtrudeChange::SetMode(_) => "Set mode",
+    }
+    .into()
+}
+
+fn fillet_undo_name(c: &FilletChange) -> String {
+    match c {
+        FilletChange::SetRadius(_) => "Set radius",
+        FilletChange::SetTarget(_) => "Set target",
+    }
+    .into()
 }

--- a/crates/modeling-module/src/persistent_data.rs
+++ b/crates/modeling-module/src/persistent_data.rs
@@ -9,8 +9,9 @@ use uuid::Uuid;
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Step {
-    name: String,
-    operation: ModelingOperation,
+    pub id: Uuid,
+    pub name: String,
+    pub operation: ModelingOperation,
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
@@ -20,6 +21,7 @@ pub struct PersistentData {
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Hash)]
 pub struct Create {
+    pub id: Uuid,
     pub before: Option<Uuid>,
     pub operation: ModelingOperation,
 }
@@ -38,6 +40,7 @@ impl DataSection for PersistentData {
         match args {
             ModelingTransaction::Create(c) => {
                 self.steps.push(Step {
+                    id: c.id,
                     name: "new operation".to_string(),
                     operation: c.operation,
                 });

--- a/crates/modeling-module/tests/extrude_and_fillet_changes.rs
+++ b/crates/modeling-module/tests/extrude_and_fillet_changes.rs
@@ -1,0 +1,46 @@
+use modeling_module::operation::extrude::{Extrude, ExtrudeChange, ExtrudeDirection, ExtrudeMode};
+use modeling_module::operation::Operation;
+use uuid::Uuid;
+
+fn ex() -> Extrude {
+    Extrude {
+        sketch_id: Uuid::nil(),
+        depth: 1.0,
+        direction: ExtrudeDirection::Normal,
+        mode: ExtrudeMode::Add,
+    }
+}
+
+#[test]
+fn extrude_set_depth_changes_only_depth() {
+    let mut e = ex();
+    e.apply_change(ExtrudeChange::SetDepth(7.5));
+    assert_eq!(e.depth, 7.5);
+    assert_eq!(e.direction, ExtrudeDirection::Normal);
+    assert_eq!(e.mode, ExtrudeMode::Add);
+}
+
+#[test]
+fn extrude_set_sketch_id_changes_only_sketch_id() {
+    let mut e = ex();
+    let new_id = Uuid::new_v4();
+    e.apply_change(ExtrudeChange::SetSketchId(new_id));
+    assert_eq!(e.sketch_id, new_id);
+    assert_eq!(e.depth, 1.0);
+}
+
+#[test]
+fn extrude_set_direction_changes_only_direction() {
+    let mut e = ex();
+    e.apply_change(ExtrudeChange::SetDirection(ExtrudeDirection::Symmetric));
+    assert_eq!(e.direction, ExtrudeDirection::Symmetric);
+    assert_eq!(e.depth, 1.0);
+}
+
+#[test]
+fn extrude_set_mode_changes_only_mode() {
+    let mut e = ex();
+    e.apply_change(ExtrudeChange::SetMode(ExtrudeMode::Subtract));
+    assert_eq!(e.mode, ExtrudeMode::Subtract);
+    assert_eq!(e.depth, 1.0);
+}

--- a/crates/modeling-module/tests/extrude_and_fillet_changes.rs
+++ b/crates/modeling-module/tests/extrude_and_fillet_changes.rs
@@ -44,3 +44,43 @@ fn extrude_set_mode_changes_only_mode() {
     assert_eq!(e.mode, ExtrudeMode::Subtract);
     assert_eq!(e.depth, 1.0);
 }
+
+use modeling_module::operation::fillet::{EdgeRef, FaceRef, Fillet, FilletChange, FilletTarget};
+
+#[test]
+fn fillet_default_is_whole_body() {
+    let f = Fillet::default();
+    assert_eq!(f.target, FilletTarget::WholeBody);
+}
+
+#[test]
+fn fillet_set_radius_changes_only_radius() {
+    let mut f = Fillet {
+        radius: 0.5,
+        target: FilletTarget::WholeBody,
+    };
+    f.apply_change(FilletChange::SetRadius(1.25));
+    assert_eq!(f.radius, 1.25);
+    assert_eq!(f.target, FilletTarget::WholeBody);
+}
+
+#[test]
+fn fillet_set_target_replaces_target_leaves_radius() {
+    let mut f = Fillet {
+        radius: 0.5,
+        target: FilletTarget::WholeBody,
+    };
+    f.apply_change(FilletChange::SetTarget(FilletTarget::Face(FaceRef {
+        index: 3,
+    })));
+    assert_eq!(f.target, FilletTarget::Face(FaceRef { index: 3 }));
+    assert_eq!(f.radius, 0.5);
+}
+
+#[test]
+fn fillet_set_target_to_edges() {
+    let mut f = Fillet::default();
+    let edges = vec![EdgeRef { index: 0 }, EdgeRef { index: 2 }];
+    f.apply_change(FilletChange::SetTarget(FilletTarget::Edges(edges.clone())));
+    assert_eq!(f.target, FilletTarget::Edges(edges));
+}

--- a/crates/modeling-module/tests/sketch_changes.rs
+++ b/crates/modeling-module/tests/sketch_changes.rs
@@ -21,54 +21,22 @@ fn set_plane_updates_plane() {
 }
 
 #[test]
-fn add_primitive_with_no_anchor_appends() {
-    let mut s = Sketch::default();
-    let id = Uuid::new_v4();
-    s.apply_change(SketchChange::AddPrimitive {
-        id,
-        before: None,
-        primitive: line(0.0, 0.0, 1.0, 0.0),
-    });
-    assert_eq!(s.primitives.len(), 1);
-    assert_eq!(s.primitives[0].0, id);
-}
-
-#[test]
-fn add_primitive_inserts_before_anchor() {
+fn add_primitive_appends_in_order() {
     let mut s = Sketch::default();
     let id_a = Uuid::new_v4();
     let id_b = Uuid::new_v4();
     s.apply_change(SketchChange::AddPrimitive {
         id: id_a,
-        before: None,
         primitive: line(0.0, 0.0, 1.0, 0.0),
     });
     s.apply_change(SketchChange::AddPrimitive {
         id: id_b,
-        before: Some(id_a),
         primitive: line(1.0, 0.0, 1.0, 1.0),
     });
-    assert_eq!(s.primitives[0].0, id_b);
-    assert_eq!(s.primitives[1].0, id_a);
-}
-
-#[test]
-fn add_primitive_unknown_anchor_appends() {
-    let mut s = Sketch::default();
-    let id_a = Uuid::new_v4();
-    s.apply_change(SketchChange::AddPrimitive {
-        id: id_a,
-        before: None,
-        primitive: line(0.0, 0.0, 1.0, 0.0),
-    });
-    let id_b = Uuid::new_v4();
-    s.apply_change(SketchChange::AddPrimitive {
-        id: id_b,
-        before: Some(Uuid::new_v4()),
-        primitive: line(1.0, 0.0, 1.0, 1.0),
-    });
-    assert_eq!(s.primitives.len(), 2);
-    assert_eq!(s.primitives[1].0, id_b);
+    assert_eq!(
+        s.primitives.iter().map(|(i, _)| *i).collect::<Vec<_>>(),
+        vec![id_a, id_b]
+    );
 }
 
 #[test]
@@ -77,12 +45,10 @@ fn add_primitive_duplicate_id_is_noop() {
     let id = Uuid::new_v4();
     s.apply_change(SketchChange::AddPrimitive {
         id,
-        before: None,
         primitive: line(0.0, 0.0, 1.0, 0.0),
     });
     s.apply_change(SketchChange::AddPrimitive {
         id,
-        before: None,
         primitive: line(2.0, 2.0, 3.0, 3.0),
     });
     assert_eq!(s.primitives.len(), 1);
@@ -94,7 +60,6 @@ fn delete_primitive_removes_by_id() {
     let id = Uuid::new_v4();
     s.apply_change(SketchChange::AddPrimitive {
         id,
-        before: None,
         primitive: line(0.0, 0.0, 1.0, 0.0),
     });
     s.apply_change(SketchChange::DeletePrimitive { id });
@@ -109,64 +74,11 @@ fn delete_primitive_unknown_id_is_noop() {
 }
 
 #[test]
-fn reorder_primitive_moves_with_known_anchor() {
-    let mut s = Sketch::default();
-    let id_a = Uuid::new_v4();
-    let id_b = Uuid::new_v4();
-    let id_c = Uuid::new_v4();
-    for (id, p) in [
-        (id_a, line(0.0, 0.0, 1.0, 0.0)),
-        (id_b, line(1.0, 0.0, 1.0, 1.0)),
-        (id_c, line(1.0, 1.0, 0.0, 1.0)),
-    ] {
-        s.apply_change(SketchChange::AddPrimitive {
-            id,
-            before: None,
-            primitive: p,
-        });
-    }
-    s.apply_change(SketchChange::ReorderPrimitive {
-        id: id_c,
-        before: Some(id_a),
-    });
-    assert_eq!(
-        s.primitives.iter().map(|(i, _)| *i).collect::<Vec<_>>(),
-        vec![id_c, id_a, id_b]
-    );
-}
-
-#[test]
-fn reorder_primitive_unknown_anchor_moves_to_end() {
-    let mut s = Sketch::default();
-    let id_a = Uuid::new_v4();
-    let id_b = Uuid::new_v4();
-    s.apply_change(SketchChange::AddPrimitive {
-        id: id_a,
-        before: None,
-        primitive: line(0.0, 0.0, 1.0, 0.0),
-    });
-    s.apply_change(SketchChange::AddPrimitive {
-        id: id_b,
-        before: None,
-        primitive: line(1.0, 0.0, 1.0, 1.0),
-    });
-    s.apply_change(SketchChange::ReorderPrimitive {
-        id: id_a,
-        before: Some(Uuid::new_v4()),
-    });
-    assert_eq!(
-        s.primitives.iter().map(|(i, _)| *i).collect::<Vec<_>>(),
-        vec![id_b, id_a]
-    );
-}
-
-#[test]
 fn edit_primitive_line_set_from_changes_only_from() {
     let mut s = Sketch::default();
     let id = Uuid::new_v4();
     s.apply_change(SketchChange::AddPrimitive {
         id,
-        before: None,
         primitive: line(0.0, 0.0, 1.0, 0.0),
     });
     s.apply_change(SketchChange::EditPrimitive {
@@ -186,7 +98,6 @@ fn edit_primitive_mismatched_variant_is_noop() {
     let id = Uuid::new_v4();
     s.apply_change(SketchChange::AddPrimitive {
         id,
-        before: None,
         primitive: line(0.0, 0.0, 1.0, 0.0),
     });
     s.apply_change(SketchChange::EditPrimitive {

--- a/crates/modeling-module/tests/sketch_changes.rs
+++ b/crates/modeling-module/tests/sketch_changes.rs
@@ -1,0 +1,211 @@
+use modeling_module::operation::sketch::{
+    CircleChange, LineChange, Plane, Point2D, PrimitiveChange, Sketch, SketchChange,
+    SketchPrimitive,
+};
+use modeling_module::operation::Operation;
+use uuid::Uuid;
+
+fn line(x1: f64, y1: f64, x2: f64, y2: f64) -> SketchPrimitive {
+    SketchPrimitive::Line(modeling_module::operation::sketch::Line {
+        from: Point2D::new(x1, y1),
+        to: Point2D::new(x2, y2),
+    })
+}
+
+#[test]
+fn set_plane_updates_plane() {
+    let mut s = Sketch::default();
+    assert_eq!(s.plane, Plane::XY);
+    s.apply_change(SketchChange::SetPlane(Plane::YZ));
+    assert_eq!(s.plane, Plane::YZ);
+}
+
+#[test]
+fn add_primitive_with_no_anchor_appends() {
+    let mut s = Sketch::default();
+    let id = Uuid::new_v4();
+    s.apply_change(SketchChange::AddPrimitive {
+        id,
+        before: None,
+        primitive: line(0.0, 0.0, 1.0, 0.0),
+    });
+    assert_eq!(s.primitives.len(), 1);
+    assert_eq!(s.primitives[0].0, id);
+}
+
+#[test]
+fn add_primitive_inserts_before_anchor() {
+    let mut s = Sketch::default();
+    let id_a = Uuid::new_v4();
+    let id_b = Uuid::new_v4();
+    s.apply_change(SketchChange::AddPrimitive {
+        id: id_a,
+        before: None,
+        primitive: line(0.0, 0.0, 1.0, 0.0),
+    });
+    s.apply_change(SketchChange::AddPrimitive {
+        id: id_b,
+        before: Some(id_a),
+        primitive: line(1.0, 0.0, 1.0, 1.0),
+    });
+    assert_eq!(s.primitives[0].0, id_b);
+    assert_eq!(s.primitives[1].0, id_a);
+}
+
+#[test]
+fn add_primitive_unknown_anchor_appends() {
+    let mut s = Sketch::default();
+    let id_a = Uuid::new_v4();
+    s.apply_change(SketchChange::AddPrimitive {
+        id: id_a,
+        before: None,
+        primitive: line(0.0, 0.0, 1.0, 0.0),
+    });
+    let id_b = Uuid::new_v4();
+    s.apply_change(SketchChange::AddPrimitive {
+        id: id_b,
+        before: Some(Uuid::new_v4()),
+        primitive: line(1.0, 0.0, 1.0, 1.0),
+    });
+    assert_eq!(s.primitives.len(), 2);
+    assert_eq!(s.primitives[1].0, id_b);
+}
+
+#[test]
+fn add_primitive_duplicate_id_is_noop() {
+    let mut s = Sketch::default();
+    let id = Uuid::new_v4();
+    s.apply_change(SketchChange::AddPrimitive {
+        id,
+        before: None,
+        primitive: line(0.0, 0.0, 1.0, 0.0),
+    });
+    s.apply_change(SketchChange::AddPrimitive {
+        id,
+        before: None,
+        primitive: line(2.0, 2.0, 3.0, 3.0),
+    });
+    assert_eq!(s.primitives.len(), 1);
+}
+
+#[test]
+fn delete_primitive_removes_by_id() {
+    let mut s = Sketch::default();
+    let id = Uuid::new_v4();
+    s.apply_change(SketchChange::AddPrimitive {
+        id,
+        before: None,
+        primitive: line(0.0, 0.0, 1.0, 0.0),
+    });
+    s.apply_change(SketchChange::DeletePrimitive { id });
+    assert!(s.primitives.is_empty());
+}
+
+#[test]
+fn delete_primitive_unknown_id_is_noop() {
+    let mut s = Sketch::default();
+    s.apply_change(SketchChange::DeletePrimitive { id: Uuid::new_v4() });
+    assert!(s.primitives.is_empty());
+}
+
+#[test]
+fn reorder_primitive_moves_with_known_anchor() {
+    let mut s = Sketch::default();
+    let id_a = Uuid::new_v4();
+    let id_b = Uuid::new_v4();
+    let id_c = Uuid::new_v4();
+    for (id, p) in [
+        (id_a, line(0.0, 0.0, 1.0, 0.0)),
+        (id_b, line(1.0, 0.0, 1.0, 1.0)),
+        (id_c, line(1.0, 1.0, 0.0, 1.0)),
+    ] {
+        s.apply_change(SketchChange::AddPrimitive {
+            id,
+            before: None,
+            primitive: p,
+        });
+    }
+    s.apply_change(SketchChange::ReorderPrimitive {
+        id: id_c,
+        before: Some(id_a),
+    });
+    assert_eq!(
+        s.primitives.iter().map(|(i, _)| *i).collect::<Vec<_>>(),
+        vec![id_c, id_a, id_b]
+    );
+}
+
+#[test]
+fn reorder_primitive_unknown_anchor_moves_to_end() {
+    let mut s = Sketch::default();
+    let id_a = Uuid::new_v4();
+    let id_b = Uuid::new_v4();
+    s.apply_change(SketchChange::AddPrimitive {
+        id: id_a,
+        before: None,
+        primitive: line(0.0, 0.0, 1.0, 0.0),
+    });
+    s.apply_change(SketchChange::AddPrimitive {
+        id: id_b,
+        before: None,
+        primitive: line(1.0, 0.0, 1.0, 1.0),
+    });
+    s.apply_change(SketchChange::ReorderPrimitive {
+        id: id_a,
+        before: Some(Uuid::new_v4()),
+    });
+    assert_eq!(
+        s.primitives.iter().map(|(i, _)| *i).collect::<Vec<_>>(),
+        vec![id_b, id_a]
+    );
+}
+
+#[test]
+fn edit_primitive_line_set_from_changes_only_from() {
+    let mut s = Sketch::default();
+    let id = Uuid::new_v4();
+    s.apply_change(SketchChange::AddPrimitive {
+        id,
+        before: None,
+        primitive: line(0.0, 0.0, 1.0, 0.0),
+    });
+    s.apply_change(SketchChange::EditPrimitive {
+        id,
+        change: PrimitiveChange::Line(LineChange::SetFrom(Point2D::new(5.0, 6.0))),
+    });
+    let SketchPrimitive::Line(ref l) = s.primitives[0].1 else {
+        panic!("expected Line")
+    };
+    assert_eq!((l.from.x, l.from.y), (5.0, 6.0));
+    assert_eq!((l.to.x, l.to.y), (1.0, 0.0));
+}
+
+#[test]
+fn edit_primitive_mismatched_variant_is_noop() {
+    let mut s = Sketch::default();
+    let id = Uuid::new_v4();
+    s.apply_change(SketchChange::AddPrimitive {
+        id,
+        before: None,
+        primitive: line(0.0, 0.0, 1.0, 0.0),
+    });
+    s.apply_change(SketchChange::EditPrimitive {
+        id,
+        change: PrimitiveChange::Circle(CircleChange::SetRadius(99.0)),
+    });
+    let SketchPrimitive::Line(ref l) = s.primitives[0].1 else {
+        panic!("expected Line")
+    };
+    assert_eq!((l.from.x, l.from.y), (0.0, 0.0));
+    assert_eq!((l.to.x, l.to.y), (1.0, 0.0));
+}
+
+#[test]
+fn edit_primitive_unknown_id_is_noop() {
+    let mut s = Sketch::default();
+    s.apply_change(SketchChange::EditPrimitive {
+        id: Uuid::new_v4(),
+        change: PrimitiveChange::Line(LineChange::SetFrom(Point2D::new(1.0, 1.0))),
+    });
+    assert!(s.primitives.is_empty());
+}

--- a/crates/modeling-module/tests/step_crud.rs
+++ b/crates/modeling-module/tests/step_crud.rs
@@ -1,0 +1,231 @@
+use modeling_module::operation::extrude::{Extrude, ExtrudeChange, ExtrudeMode};
+use modeling_module::operation::fillet::{Fillet, FilletChange};
+use modeling_module::operation::sketch::{Plane, Sketch, SketchChange};
+use modeling_module::operation::ModelingOperation;
+use modeling_module::persistent_data::{
+    Create, Delete, ModelingTransaction, PersistentData, Rename, Reorder,
+};
+use module::DataSection;
+use uuid::Uuid;
+
+fn op_sketch() -> ModelingOperation {
+    ModelingOperation::Sketch(Sketch::default())
+}
+
+fn create(id: Uuid, name: &str, before: Option<Uuid>) -> ModelingTransaction {
+    ModelingTransaction::Create(Create {
+        id,
+        before,
+        name: name.to_string(),
+        operation: op_sketch(),
+    })
+}
+
+#[test]
+fn create_with_no_anchor_appends() {
+    let mut pd = PersistentData::default();
+    let id = Uuid::new_v4();
+    pd.apply(create(id, "s1", None));
+    assert_eq!(pd.steps().len(), 1);
+    assert_eq!(pd.steps()[0].id, id);
+}
+
+#[test]
+fn create_with_known_anchor_inserts_before() {
+    let mut pd = PersistentData::default();
+    let a = Uuid::new_v4();
+    let b = Uuid::new_v4();
+    pd.apply(create(a, "a", None));
+    pd.apply(create(b, "b", Some(a)));
+    assert_eq!(pd.steps()[0].id, b);
+    assert_eq!(pd.steps()[1].id, a);
+}
+
+#[test]
+fn create_with_unknown_anchor_appends() {
+    let mut pd = PersistentData::default();
+    let a = Uuid::new_v4();
+    pd.apply(create(a, "a", None));
+    let b = Uuid::new_v4();
+    pd.apply(create(b, "b", Some(Uuid::new_v4())));
+    assert_eq!(pd.steps().last().unwrap().id, b);
+}
+
+#[test]
+fn create_with_duplicate_id_is_noop() {
+    let mut pd = PersistentData::default();
+    let id = Uuid::new_v4();
+    pd.apply(create(id, "a", None));
+    pd.apply(create(id, "b", None));
+    assert_eq!(pd.steps().len(), 1);
+}
+
+#[test]
+fn delete_by_known_id_removes() {
+    let mut pd = PersistentData::default();
+    let id = Uuid::new_v4();
+    pd.apply(create(id, "a", None));
+    pd.apply(ModelingTransaction::Delete(Delete { id }));
+    assert!(pd.steps().is_empty());
+}
+
+#[test]
+fn delete_by_unknown_id_is_noop() {
+    let mut pd = PersistentData::default();
+    pd.apply(ModelingTransaction::Delete(Delete { id: Uuid::new_v4() }));
+    assert!(pd.steps().is_empty());
+}
+
+#[test]
+fn rename_changes_only_name() {
+    let mut pd = PersistentData::default();
+    let id = Uuid::new_v4();
+    pd.apply(create(id, "old", None));
+    pd.apply(ModelingTransaction::Rename(Rename {
+        id,
+        new_name: "new".into(),
+    }));
+    assert_eq!(pd.steps()[0].name, "new");
+}
+
+#[test]
+fn rename_unknown_id_is_noop() {
+    let mut pd = PersistentData::default();
+    pd.apply(ModelingTransaction::Rename(Rename {
+        id: Uuid::new_v4(),
+        new_name: "x".into(),
+    }));
+    assert!(pd.steps().is_empty());
+}
+
+#[test]
+fn reorder_with_known_anchor_moves() {
+    let mut pd = PersistentData::default();
+    let a = Uuid::new_v4();
+    let b = Uuid::new_v4();
+    let c = Uuid::new_v4();
+    for (id, n) in [(a, "a"), (b, "b"), (c, "c")] {
+        pd.apply(create(id, n, None));
+    }
+    pd.apply(ModelingTransaction::Reorder(Reorder {
+        id: c,
+        before: Some(a),
+    }));
+    assert_eq!(
+        pd.steps().iter().map(|s| s.id).collect::<Vec<_>>(),
+        vec![c, a, b]
+    );
+}
+
+#[test]
+fn reorder_with_unknown_anchor_moves_to_end() {
+    let mut pd = PersistentData::default();
+    let a = Uuid::new_v4();
+    let b = Uuid::new_v4();
+    pd.apply(create(a, "a", None));
+    pd.apply(create(b, "b", None));
+    pd.apply(ModelingTransaction::Reorder(Reorder {
+        id: a,
+        before: Some(Uuid::new_v4()),
+    }));
+    assert_eq!(
+        pd.steps().iter().map(|s| s.id).collect::<Vec<_>>(),
+        vec![b, a]
+    );
+}
+
+#[test]
+fn reorder_unknown_id_is_noop() {
+    let mut pd = PersistentData::default();
+    let a = Uuid::new_v4();
+    pd.apply(create(a, "a", None));
+    pd.apply(ModelingTransaction::Reorder(Reorder {
+        id: Uuid::new_v4(),
+        before: None,
+    }));
+    assert_eq!(pd.steps().len(), 1);
+}
+
+#[test]
+fn edit_sketch_set_plane_dispatches_to_sketch() {
+    let mut pd = PersistentData::default();
+    let id = Uuid::new_v4();
+    pd.apply(create(id, "s", None));
+    pd.apply(ModelingTransaction::EditSketch {
+        step_id: id,
+        change: SketchChange::SetPlane(Plane::YZ),
+    });
+    let ModelingOperation::Sketch(ref s) = pd.steps()[0].operation else {
+        panic!()
+    };
+    assert_eq!(s.plane, Plane::YZ);
+}
+
+#[test]
+fn edit_sketch_on_extrude_step_is_noop() {
+    let mut pd = PersistentData::default();
+    let id = Uuid::new_v4();
+    pd.apply(ModelingTransaction::Create(Create {
+        id,
+        before: None,
+        name: "e".into(),
+        operation: ModelingOperation::Extrude(Extrude::default()),
+    }));
+    pd.apply(ModelingTransaction::EditSketch {
+        step_id: id,
+        change: SketchChange::SetPlane(Plane::YZ),
+    });
+    let ModelingOperation::Extrude(_) = pd.steps()[0].operation else {
+        panic!()
+    };
+}
+
+#[test]
+fn edit_extrude_dispatches_to_extrude() {
+    let mut pd = PersistentData::default();
+    let id = Uuid::new_v4();
+    pd.apply(ModelingTransaction::Create(Create {
+        id,
+        before: None,
+        name: "e".into(),
+        operation: ModelingOperation::Extrude(Extrude::default()),
+    }));
+    pd.apply(ModelingTransaction::EditExtrude {
+        step_id: id,
+        change: ExtrudeChange::SetMode(ExtrudeMode::Subtract),
+    });
+    let ModelingOperation::Extrude(ref e) = pd.steps()[0].operation else {
+        panic!()
+    };
+    assert_eq!(e.mode, ExtrudeMode::Subtract);
+}
+
+#[test]
+fn edit_fillet_dispatches_to_fillet() {
+    let mut pd = PersistentData::default();
+    let id = Uuid::new_v4();
+    pd.apply(ModelingTransaction::Create(Create {
+        id,
+        before: None,
+        name: "f".into(),
+        operation: ModelingOperation::Fillet(Fillet::default()),
+    }));
+    pd.apply(ModelingTransaction::EditFillet {
+        step_id: id,
+        change: FilletChange::SetRadius(2.5),
+    });
+    let ModelingOperation::Fillet(ref f) = pd.steps()[0].operation else {
+        panic!()
+    };
+    assert_eq!(f.radius, 2.5);
+}
+
+#[test]
+fn edit_with_unknown_step_id_is_noop() {
+    let mut pd = PersistentData::default();
+    pd.apply(ModelingTransaction::EditSketch {
+        step_id: Uuid::new_v4(),
+        change: SketchChange::SetPlane(Plane::YZ),
+    });
+    assert!(pd.steps().is_empty());
+}

--- a/crates/modeling-module/tests/walk.rs
+++ b/crates/modeling-module/tests/walk.rs
@@ -1,0 +1,288 @@
+use modeling_module::operation::extrude::{Extrude, ExtrudeDirection, ExtrudeMode};
+use modeling_module::operation::fillet::{EdgeRef, Fillet, FilletTarget};
+use modeling_module::operation::sketch::{Line, Plane, Point2D, Sketch, SketchPrimitive};
+use modeling_module::operation::ModelingOperation;
+use modeling_module::persistent_data::{Create, ModelingTransaction, PersistentData};
+use module::DataSection;
+use uuid::Uuid;
+
+fn add(pd: &mut PersistentData, id: Uuid, op: ModelingOperation) {
+    pd.apply(ModelingTransaction::Create(Create {
+        id,
+        before: None,
+        name: "x".into(),
+        operation: op,
+    }));
+}
+
+fn square_sketch_xy() -> Sketch {
+    let prims = vec![
+        (
+            Uuid::new_v4(),
+            SketchPrimitive::Line(Line {
+                from: Point2D::new(0.0, 0.0),
+                to: Point2D::new(1.0, 0.0),
+            }),
+        ),
+        (
+            Uuid::new_v4(),
+            SketchPrimitive::Line(Line {
+                from: Point2D::new(1.0, 0.0),
+                to: Point2D::new(1.0, 1.0),
+            }),
+        ),
+        (
+            Uuid::new_v4(),
+            SketchPrimitive::Line(Line {
+                from: Point2D::new(1.0, 1.0),
+                to: Point2D::new(0.0, 1.0),
+            }),
+        ),
+        (
+            Uuid::new_v4(),
+            SketchPrimitive::Line(Line {
+                from: Point2D::new(0.0, 1.0),
+                to: Point2D::new(0.0, 0.0),
+            }),
+        ),
+    ];
+    Sketch {
+        plane: Plane::XY,
+        primitives: prims,
+    }
+}
+
+fn bbox(pd: &PersistentData) -> (f64, f64, f64, f64, f64, f64) {
+    let verts = pd.shape().mesh().vertices();
+    if verts.is_empty() {
+        return (0.0, 0.0, 0.0, 0.0, 0.0, 0.0);
+    }
+    let (mut minx, mut maxx) = (f64::INFINITY, f64::NEG_INFINITY);
+    let (mut miny, mut maxy) = (f64::INFINITY, f64::NEG_INFINITY);
+    let (mut minz, mut maxz) = (f64::INFINITY, f64::NEG_INFINITY);
+    for v in &verts {
+        minx = minx.min(v.x());
+        maxx = maxx.max(v.x());
+        miny = miny.min(v.y());
+        maxy = maxy.max(v.y());
+        minz = minz.min(v.z());
+        maxz = maxz.max(v.z());
+    }
+    (minx, maxx, miny, maxy, minz, maxz)
+}
+
+#[test]
+fn empty_steps_produces_empty_mesh() {
+    let pd = PersistentData::default();
+    assert!(pd.shape().mesh().vertices().is_empty());
+}
+
+#[test]
+fn sketch_alone_produces_empty_mesh() {
+    let mut pd = PersistentData::default();
+    add(
+        &mut pd,
+        Uuid::new_v4(),
+        ModelingOperation::Sketch(square_sketch_xy()),
+    );
+    assert!(pd.shape().mesh().vertices().is_empty());
+}
+
+#[test]
+fn add_extrude_on_empty_seeds_body() {
+    let mut pd = PersistentData::default();
+    let sketch_id = Uuid::new_v4();
+    add(
+        &mut pd,
+        sketch_id,
+        ModelingOperation::Sketch(square_sketch_xy()),
+    );
+    add(
+        &mut pd,
+        Uuid::new_v4(),
+        ModelingOperation::Extrude(Extrude {
+            sketch_id,
+            depth: 2.0,
+            direction: ExtrudeDirection::Normal,
+            mode: ExtrudeMode::Add,
+        }),
+    );
+    let (minx, maxx, miny, maxy, minz, maxz) = bbox(&pd);
+    assert!(
+        (maxx - minx - 1.0).abs() < 1e-6,
+        "x extent != 1: {}",
+        maxx - minx
+    );
+    assert!(
+        (maxy - miny - 1.0).abs() < 1e-6,
+        "y extent != 1: {}",
+        maxy - miny
+    );
+    assert!(
+        (maxz - minz - 2.0).abs() < 1e-6,
+        "z extent != 2: {}",
+        maxz - minz
+    );
+}
+
+#[test]
+fn subtract_on_empty_is_noop() {
+    let mut pd = PersistentData::default();
+    let sketch_id = Uuid::new_v4();
+    add(
+        &mut pd,
+        sketch_id,
+        ModelingOperation::Sketch(square_sketch_xy()),
+    );
+    add(
+        &mut pd,
+        Uuid::new_v4(),
+        ModelingOperation::Extrude(Extrude {
+            sketch_id,
+            depth: 2.0,
+            direction: ExtrudeDirection::Normal,
+            mode: ExtrudeMode::Subtract,
+        }),
+    );
+    assert!(pd.shape().mesh().vertices().is_empty());
+}
+
+#[test]
+fn extrude_with_unknown_sketch_id_is_skipped() {
+    let mut pd = PersistentData::default();
+    add(
+        &mut pd,
+        Uuid::new_v4(),
+        ModelingOperation::Extrude(Extrude {
+            sketch_id: Uuid::new_v4(),
+            depth: 1.0,
+            direction: ExtrudeDirection::Normal,
+            mode: ExtrudeMode::Add,
+        }),
+    );
+    assert!(pd.shape().mesh().vertices().is_empty());
+}
+
+#[test]
+fn extrude_referencing_non_sketch_step_is_skipped() {
+    let mut pd = PersistentData::default();
+    let fillet_id = Uuid::new_v4();
+    add(
+        &mut pd,
+        fillet_id,
+        ModelingOperation::Fillet(Fillet::default()),
+    );
+    add(
+        &mut pd,
+        Uuid::new_v4(),
+        ModelingOperation::Extrude(Extrude {
+            sketch_id: fillet_id,
+            depth: 1.0,
+            direction: ExtrudeDirection::Normal,
+            mode: ExtrudeMode::Add,
+        }),
+    );
+    assert!(pd.shape().mesh().vertices().is_empty());
+}
+
+#[test]
+fn fillet_whole_body_shrinks_bounding_box_or_equal() {
+    let mut pd = PersistentData::default();
+    let sketch_id = Uuid::new_v4();
+    add(
+        &mut pd,
+        sketch_id,
+        ModelingOperation::Sketch(square_sketch_xy()),
+    );
+    add(
+        &mut pd,
+        Uuid::new_v4(),
+        ModelingOperation::Extrude(Extrude {
+            sketch_id,
+            depth: 1.0,
+            direction: ExtrudeDirection::Normal,
+            mode: ExtrudeMode::Add,
+        }),
+    );
+    let (minx0, maxx0, _, _, _, _) = bbox(&pd);
+    add(
+        &mut pd,
+        Uuid::new_v4(),
+        ModelingOperation::Fillet(Fillet {
+            radius: 0.1,
+            target: FilletTarget::WholeBody,
+        }),
+    );
+    let (minx1, maxx1, _, _, _, _) = bbox(&pd);
+    assert!(
+        maxx1 - minx1 <= maxx0 - minx0 + 1e-9,
+        "filleted x-extent should be <= unfilleted"
+    );
+}
+
+#[test]
+fn fillet_with_all_out_of_range_edges_is_noop() {
+    let mut pd = PersistentData::default();
+    let sketch_id = Uuid::new_v4();
+    add(
+        &mut pd,
+        sketch_id,
+        ModelingOperation::Sketch(square_sketch_xy()),
+    );
+    add(
+        &mut pd,
+        Uuid::new_v4(),
+        ModelingOperation::Extrude(Extrude {
+            sketch_id,
+            depth: 1.0,
+            direction: ExtrudeDirection::Normal,
+            mode: ExtrudeMode::Add,
+        }),
+    );
+    let before = bbox(&pd);
+    add(
+        &mut pd,
+        Uuid::new_v4(),
+        ModelingOperation::Fillet(Fillet {
+            radius: 0.1,
+            target: FilletTarget::Edges(vec![EdgeRef { index: 9999 }]),
+        }),
+    );
+    let after = bbox(&pd);
+    assert_eq!(before, after, "out-of-range fillet must not change body");
+}
+
+#[test]
+fn yz_sketch_extrudes_along_x() {
+    let mut pd = PersistentData::default();
+    let sketch_id = Uuid::new_v4();
+    let mut s = square_sketch_xy();
+    s.plane = Plane::YZ;
+    add(&mut pd, sketch_id, ModelingOperation::Sketch(s));
+    add(
+        &mut pd,
+        Uuid::new_v4(),
+        ModelingOperation::Extrude(Extrude {
+            sketch_id,
+            depth: 2.0,
+            direction: ExtrudeDirection::Normal,
+            mode: ExtrudeMode::Add,
+        }),
+    );
+    let (minx, maxx, miny, maxy, minz, maxz) = bbox(&pd);
+    assert!(
+        (maxx - minx - 2.0).abs() < 1e-6,
+        "x should extend along extrude direction (depth=2): got {}",
+        maxx - minx
+    );
+    assert!(
+        (maxy - miny - 1.0).abs() < 1e-6,
+        "y extent should be unit: got {}",
+        maxy - miny
+    );
+    assert!(
+        (maxz - minz - 1.0).abs() < 1e-6,
+        "z extent should be unit: got {}",
+        maxz - minz
+    );
+}

--- a/crates/occara/include/cxx_wrapper.hpp
+++ b/crates/occara/include/cxx_wrapper.hpp
@@ -531,5 +531,5 @@ inline std::unique_ptr<geom::Point> Mesh_vertices_at(const Mesh& m, size_t index
 #include "internal/MakeBottle.hpp"
 
 inline std::unique_ptr<occara::shape::Shape> MakeBottle_wrapper(Standard_Real theWidth, Standard_Real theHeight, Standard_Real theThickness) {
-    return std::make_unique<occara::shape::Shape>(std::move(MakeBottle(theWidth, theHeight, theThickness)));
+    return std::make_unique<occara::shape::Shape>(MakeBottle(theWidth, theHeight, theThickness));
 }

--- a/crates/occara/include/cxx_wrapper.hpp
+++ b/crates/occara/include/cxx_wrapper.hpp
@@ -2,6 +2,7 @@
 #include "geom.hpp"
 #include "shape.hpp"
 #include <Standard_Failure.hxx>
+#include <gp_Circ.hxx>
 #include <memory>
 #include <stdexcept>
 
@@ -364,12 +365,28 @@ inline std::unique_ptr<Edge> Edge_from_2d_curve(const geom::Curve2D& curve, cons
     return std::make_unique<Edge>(Edge::from_2d_curve(curve, surface));
 }
 
+inline std::unique_ptr<Edge> Edge_circle(
+    const geom::Point& center,
+    const geom::Direction& normal,
+    Standard_Real radius) {
+    gp_Ax2 ax(center.point, normal.direction);
+    gp_Circ circ(ax, radius);
+    BRepBuilderAPI_MakeEdge builder(circ);
+    return std::make_unique<Edge>(Edge{builder.Edge()});
+}
+
 // EdgeIterator wrappers
 inline std::unique_ptr<EdgeIterator> EdgeIterator_create(const Shape& shape) {
     // Use the static create method and move the result
     auto it_value = EdgeIterator::create(shape);
     // Create unique_ptr by copying (EdgeIterator should be copyable)
     return std::make_unique<EdgeIterator>(std::move(it_value));
+}
+
+inline std::unique_ptr<EdgeIterator> EdgeIterator_create_from_face(const Face& face) {
+    EdgeIterator it;
+    it.explorer = std::make_shared<TopExp_Explorer>(face.face, TopAbs_EDGE);
+    return std::make_unique<EdgeIterator>(std::move(it));
 }
 
 inline std::unique_ptr<EdgeIterator> EdgeIterator_clone(const EdgeIterator& it) {

--- a/crates/occara/src/ffi.rs
+++ b/crates/occara/src/ffi.rs
@@ -308,10 +308,14 @@ pub mod ffi {
         fn Edge_clone(edge: &Edge) -> UniquePtr<Edge>;
         #[namespace = "occara::shape"]
         fn Edge_from_2d_curve(curve: &Curve2D, surface: &Surface) -> UniquePtr<Edge>;
+        #[namespace = "occara::shape"]
+        fn Edge_circle(center: &Point, normal: &Direction, radius: f64) -> UniquePtr<Edge>;
 
         // EdgeIterator functions
         #[namespace = "occara::shape"]
         fn EdgeIterator_create(shape: &Shape) -> UniquePtr<EdgeIterator>;
+        #[namespace = "occara::shape"]
+        fn EdgeIterator_create_from_face(face: &Face) -> UniquePtr<EdgeIterator>;
         #[namespace = "occara::shape"]
         fn EdgeIterator_clone(edge_iterator: &EdgeIterator) -> UniquePtr<EdgeIterator>;
         #[namespace = "occara::shape"]

--- a/crates/occara/src/shape.rs
+++ b/crates/occara/src/shape.rs
@@ -449,6 +449,11 @@ impl Edge {
     }
 
     #[must_use]
+    pub fn circle(center: &geom::Point, normal: &geom::Direction, radius: f64) -> Self {
+        Self(ffi::Edge_circle(&center.0, &normal.0, radius))
+    }
+
+    #[must_use]
     pub fn line(p1: &geom::Point, p2: &geom::Point) -> Self {
         geom::TrimmedCurve::line(p1, p2).into()
     }
@@ -492,6 +497,11 @@ impl Face {
     #[must_use]
     pub fn extrude(&self, vec: &geom::Vector) -> Shape {
         Shape(ffi::Face_extrude(&self.0, &vec.0))
+    }
+
+    #[must_use]
+    pub fn edges(&self) -> EdgeIterator {
+        EdgeIterator(ffi::EdgeIterator_create_from_face(&self.0))
     }
 
     #[must_use]

--- a/crates/occara/tests/boolean.rs
+++ b/crates/occara/tests/boolean.rs
@@ -1,6 +1,6 @@
 use occara::{
     geom::{Direction, Point},
-    shape::Shape,
+    shape::{Edge, Shape, Wire},
 };
 use wasm_bindgen_test::*;
 
@@ -27,4 +27,60 @@ fn test_subtract_smaller_cylinder_from_bigger() {
 
     assert!((max_r - 2.0).abs() < 1e-6, "outer radius wrong: {max_r}");
     assert!((min_r - 1.0).abs() < 1e-6, "inner radius wrong: {min_r}");
+}
+
+#[wasm_bindgen_test(unsupported = test)]
+fn test_circle_edge_forms_closed_wire() {
+    wasm_libc::init();
+    let center = Point::new(0.0, 0.0, 0.0);
+    let normal = Direction::z();
+    let edge = Edge::circle(&center, &normal, 1.5);
+
+    let wire = Wire::new(&[&edge]);
+    let face = wire.face();
+
+    let mesh = face
+        .extrude(&occara::geom::Vector::new(0.0, 0.0, 0.5))
+        .mesh();
+    let verts = mesh.vertices();
+
+    let max_r = verts
+        .iter()
+        .map(|v| (v.x().powi(2) + v.y().powi(2)).sqrt())
+        .fold(0.0, f64::max);
+    let min_z = verts.iter().map(|v| v.z()).fold(f64::INFINITY, f64::min);
+    let max_z = verts
+        .iter()
+        .map(|v| v.z())
+        .fold(f64::NEG_INFINITY, f64::max);
+
+    assert!((max_r - 1.5).abs() < 1e-6, "circle radius wrong: {max_r}");
+    assert!(
+        (max_z - min_z - 0.5).abs() < 1e-6,
+        "height wrong: {}",
+        max_z - min_z
+    );
+}
+
+#[wasm_bindgen_test(unsupported = test)]
+fn test_face_edges_returns_face_boundary() {
+    wasm_libc::init();
+    // A square face has 4 boundary edges. (BREP may include seam edges; we
+    // just assert at least 4 and that all edges are valid by counting them.)
+    let p1 = Point::new(0.0, 0.0, 0.0);
+    let p2 = Point::new(1.0, 0.0, 0.0);
+    let p3 = Point::new(1.0, 1.0, 0.0);
+    let p4 = Point::new(0.0, 1.0, 0.0);
+    let wire = Wire::new(&[
+        &Edge::line(&p1, &p2),
+        &Edge::line(&p2, &p3),
+        &Edge::line(&p3, &p4),
+        &Edge::line(&p4, &p1),
+    ]);
+    let face = wire.face();
+    let edge_count = face.edges().count();
+    assert!(
+        edge_count >= 4,
+        "expected at least 4 face edges, got {edge_count}"
+    );
 }

--- a/crates/occara/tests/boolean.rs
+++ b/crates/occara/tests/boolean.rs
@@ -1,0 +1,30 @@
+use occara::{
+    geom::{Direction, Point},
+    shape::Shape,
+};
+use wasm_bindgen_test::*;
+
+#[wasm_bindgen_test(unsupported = test)]
+fn test_subtract_smaller_cylinder_from_bigger() {
+    wasm_libc::init();
+    let plane = Point::new(0.0, 0.0, 0.0).plane_axis_with(&Direction::z());
+    let big = Shape::cylinder(&plane, 2.0, 1.0);
+    let small = Shape::cylinder(&plane, 1.0, 1.0);
+
+    let result = big.subtract(&small);
+    let mesh = result.mesh();
+    let verts = mesh.vertices();
+
+    let max_r = verts
+        .iter()
+        .map(|v| (v.x().powi(2) + v.y().powi(2)).sqrt())
+        .fold(0.0, f64::max);
+    let min_r = verts
+        .iter()
+        .filter(|v| (v.x().powi(2) + v.y().powi(2)).sqrt() > 0.01)
+        .map(|v| (v.x().powi(2) + v.y().powi(2)).sqrt())
+        .fold(f64::INFINITY, f64::min);
+
+    assert!((max_r - 2.0).abs() < 1e-6, "outer radius wrong: {max_r}");
+    assert!((min_r - 1.0).abs() < 1e-6, "inner radius wrong: {min_r}");
+}


### PR DESCRIPTION
This PR adds a simple modeling module that manages an ordered list of steps building a 3D body. A step is a Sketch (primitives on the XY, YZ, or XZ plane), an Extrude (Add or Subtract, with depth and direction), or a Fillet (applied to the whole body, a face, or selected edges), and each one exposes granular field level edit transactions so simultaneous edits merge through the project op log. Walking the steps in order evaluates them through `occara`/`OpenCASCADE` to produce the body, and the demo drives it by animating the extrude depth. Also adds the occara helpers this needs (`Edge::circle`, `Face::edges`) and a `Shape::subtract` test.

Closes #57.